### PR TITLE
build: add sources and javadoc jar generation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,26 @@ To keep this document concise, please see the Development Guide for all testing 
 - Docker image tests: dev-docs/DEVELOPMENT.md#docker-integration-tests
 - Coverage reports: dev-docs/DEVELOPMENT.md#testing
 
+## Publishing to Maven Local
+
+To install the project artifacts to your local Maven repository for testing or local development:
+
+```bash
+./gradlew publishToMavenLocal
+```
+
+This publishes the following artifacts to `~/.m2/repository/org/apache/solr/solr-mcp/{version}/`:
+
+- `solr-mcp-{version}.jar` - Main application JAR
+- `solr-mcp-{version}-sources.jar` - Source code for IDE navigation
+- `solr-mcp-{version}-javadoc.jar` - API documentation
+- `solr-mcp-{version}.pom` - Maven POM with dependencies
+
+This is useful when:
+- Testing the library locally before publishing to a remote repository
+- Sharing artifacts between local projects during development
+- Verifying the published POM and artifact structure
+
 ## Submitting Changes
 
 ### Pull Request Process

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
     java
+    `maven-publish`
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
     jacoco
@@ -33,6 +34,48 @@ version = "0.0.2-SNAPSHOT"
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
+    }
+    withSourcesJar()
+    withJavadocJar()
+}
+
+// Maven Publishing Configuration
+// ==============================
+// This configuration enables publishing the project artifacts to Maven repositories.
+// The publishing block defines what artifacts are published and where they go.
+//
+// Artifacts Published:
+// -------------------
+// - Main JAR: The compiled application JAR
+// - Sources JAR: Source code for IDE navigation and debugging
+// - Javadoc JAR: Generated API documentation
+//
+// Publishing to Maven Local:
+// -------------------------
+// To install artifacts to your local Maven repository (~/.m2/repository):
+//   ./gradlew publishToMavenLocal
+//
+// This is useful for:
+// - Testing the library locally before publishing to a remote repository
+// - Sharing artifacts between local projects during development
+// - Verifying the published POM and artifact structure
+//
+// After publishing, artifacts will be available at:
+//   ~/.m2/repository/org/apache/solr/solr-mcp/{version}/
+//
+// The publication includes:
+// - solr-mcp-{version}.jar (main artifact)
+// - solr-mcp-{version}-sources.jar (source code)
+// - solr-mcp-{version}-javadoc.jar (API documentation)
+// - solr-mcp-{version}.pom (Maven POM with dependencies)
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            // Include the main JAR and all artifacts from the java component
+            // This automatically includes sources and javadoc JARs when
+            // withSourcesJar() and withJavadocJar() are configured above
+            from(components["java"])
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Enable publishing of source code and javadoc artifacts alongside the main JAR
- Adds `withSourcesJar()` and `withJavadocJar()` to the Gradle build configuration
- Provides better IDE support and debugging capabilities for consumers

## Changes
- `build.gradle.kts`: Added sources and javadoc jar generation to the java block

## Test plan
- [ ] Verify `./gradlew build` completes successfully
- [ ] Check that `build/libs/` contains `-sources.jar` and `-javadoc.jar` artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)