### PR TITLE
fix: remove SNAPSHOT suffix from GA release in MCP Registry

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -376,8 +376,8 @@ jobs:
                 VERSION="${{ steps.mcp_version.outputs.version }}"
                 # Update the top-level server version (e.g., 1.2.3)
                 jq --arg v "$VERSION" '.version = $v' server.json > server.json.tmp
-                # Update package version (uses -SNAPSHOT suffix for image/JAR alignment if applicable)
-                jq --arg v "$VERSION-SNAPSHOT" '.packages[0].version = $v' server.json.tmp > server.json
+                # Update package version to match GA release (no -SNAPSHOT suffix)
+                jq --arg v "$VERSION" '.packages[0].version = $v' server.json.tmp > server.json
                 rm server.json.tmp
                 # Show the final server.json for auditing
                 cat server.json


### PR DESCRIPTION
## Summary

Fixes a bug where the `server.json` package version was incorrectly appending `-SNAPSHOT` suffix when publishing official GA releases to the MCP Registry.

## Problem

In `release-publish.yml` line 380, the package version was set to `$VERSION-SNAPSHOT`:
```yaml
jq --arg v "$VERSION-SNAPSHOT" '.packages[0].version = $v' server.json.tmp > server.json
```

This is semantically incorrect for production GA releases.

## Fix

Changed to use the GA version without `-SNAPSHOT` suffix:
```yaml
jq --arg v "$VERSION" '.packages[0].version = $v' server.json.tmp > server.json
```

## Test plan
- [ ] Verify `release-publish.yml` workflow runs successfully
- [ ] Verify `server.json` contains correct GA version without `-SNAPSHOT`

## Related

This is part of a series of PRs to improve release workflow consistency:
- PR #35: Add git-semver-plugin for automated versioning
- (Future) Centralize Java version configuration
- (Future) Simplify workflow structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)