### PR TITLE
chore: centralize Java version configuration in composite action

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Composite action for setting up Java environment
+# Centralizes Java version configuration to avoid duplication across workflows
+#
+# Usage in workflows:
+#   - uses: ./.github/actions/setup-java
+#
+# To update Java version, change JAVA_VERSION below.
+# All workflows using this action will automatically use the new version.
+
+name: 'Setup Java'
+description: 'Set up Java environment with Gradle caching'
+
+outputs:
+  java-version:
+    description: 'The Java version that was set up'
+    value: ${{ steps.setup.outputs.version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up JDK
+      id: setup
+      uses: actions/setup-java@v4
+      with:
+        # ============================================
+        # CENTRALIZED JAVA VERSION CONFIGURATION
+        # Change this value to update Java across all workflows
+        # ============================================
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'gradle'
+
+    - name: Grant execute permission for gradlew
+      shell: bash
+      run: chmod +x gradlew

--- a/.github/workflows/atr-release-test.yml
+++ b/.github/workflows/atr-release-test.yml
@@ -95,8 +95,6 @@ permissions:
     packages: write   # May be needed for publishing artifacts
 
 env:
-    JAVA_VERSION: '25'
-    JAVA_DISTRIBUTION: 'temurin'
     ATR_PROJECT_NAME: 'solr-mcp'  # Project identifier in ATR platform
 
 jobs:
@@ -128,15 +126,10 @@ jobs:
                       echo "Test tag already exists: ${TEST_TAG}"
                     fi
 
-            -   name: Set up JDK ${{ env.JAVA_VERSION }}
-                uses: actions/setup-java@v4
-                with:
-                    java-version: ${{ env.JAVA_VERSION }}
-                    distribution: ${{ env.JAVA_DISTRIBUTION }}
-                    cache: 'gradle'
-
-            -   name: Grant execute permission for gradlew
-                run: chmod +x gradlew
+            # Set up Java environment using centralized configuration
+            # See .github/actions/setup-java/action.yml to update Java version
+            -   name: Set up Java
+                uses: ./.github/actions/setup-java
 
             -   name: Build project
                 run: |

--- a/.github/workflows/atr-release.yml
+++ b/.github/workflows/atr-release.yml
@@ -137,8 +137,6 @@ permissions:
     packages: write   # May be needed for publishing artifacts
 
 env:
-    JAVA_VERSION: '25'
-    JAVA_DISTRIBUTION: 'temurin'
     ATR_PROJECT_NAME: 'solr-mcp'  # Project identifier in ATR platform
 
 jobs:
@@ -167,15 +165,10 @@ jobs:
                     fi
                     echo "✓ Release tag verified"
 
-            -   name: Set up JDK ${{ env.JAVA_VERSION }}
-                uses: actions/setup-java@v4
-                with:
-                    java-version: ${{ env.JAVA_VERSION }}
-                    distribution: ${{ env.JAVA_DISTRIBUTION }}
-                    cache: 'gradle'
-
-            -   name: Grant execute permission for gradlew
-                run: chmod +x gradlew
+            # Set up Java environment using centralized configuration
+            # See .github/actions/setup-java/action.yml to update Java version
+            -   name: Set up Java
+                uses: ./.github/actions/setup-java
 
             -   name: Build project
                 run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -109,13 +109,6 @@ on:
             - main            # Build + test validation for incoming changes
     workflow_dispatch:        # Manual runs for maintainers
 
-# Global environment used by all jobs in this workflow
-# - JAVA_VERSION: JDK version to install for Gradle builds
-# - JAVA_DISTRIBUTION: Vendor/distribution of the JDK (Temurin is Eclipse Adoptium)
-env:
-    JAVA_VERSION: '25'
-    JAVA_DISTRIBUTION: 'temurin'
-
 jobs:
     # ============================================================================
     # Job 1: Build JAR
@@ -138,20 +131,10 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v4
 
-            # Set up Java Development Kit
-            # Uses Temurin (Eclipse Adoptium) distribution of OpenJDK 25
-            # Gradle cache is enabled to speed up subsequent builds
-            -   name: Set up JDK ${{ env.JAVA_VERSION }}
-                uses: actions/setup-java@v4
-                with:
-                    java-version: ${{ env.JAVA_VERSION }}
-                    distribution: ${{ env.JAVA_DISTRIBUTION }}
-                    cache: 'gradle'
-
-            # Make the Gradle wrapper executable
-            # Required on Unix-based systems (Linux, macOS)
-            -   name: Grant execute permission for gradlew
-                run: chmod +x gradlew
+            # Set up Java environment using centralized configuration
+            # See .github/actions/setup-java/action.yml to update Java version
+            -   name: Set up Java
+                uses: ./.github/actions/setup-java
 
             # Build the project with Gradle
             # This runs: compilation, tests, spotless formatting, error-prone checks,
@@ -228,18 +211,10 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v4
 
-            # Set up Java for running Jib
-            # Jib doesn't require Docker but needs Java to run
-            -   name: Set up JDK ${{ env.JAVA_VERSION }}
-                uses: actions/setup-java@v4
-                with:
-                    java-version: ${{ env.JAVA_VERSION }}
-                    distribution: ${{ env.JAVA_DISTRIBUTION }}
-                    cache: 'gradle'
-
-            # Make Gradle wrapper executable
-            -   name: Grant execute permission for gradlew
-                run: chmod +x gradlew
+            # Set up Java environment using centralized configuration
+            # See .github/actions/setup-java/action.yml to update Java version
+            -   name: Set up Java
+                uses: ./.github/actions/setup-java
 
             # Extract version and determine image tags
             # Outputs:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -91,13 +91,6 @@ on:
         type: boolean
         default: false
 
-# Environment variables used by steps below
-# - JAVA_VERSION: selects the JDK version used to build and run Gradle
-# - JAVA_DISTRIBUTION: selects the vendor (Temurin = Eclipse Adoptium)
-env:
-  JAVA_VERSION: '25'
-  JAVA_DISTRIBUTION: 'temurin'
-
 jobs:
   nightly-build:
     name: Nightly Build and Publish
@@ -114,15 +107,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          cache: 'gradle'
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      # Set up Java environment using centralized configuration
+      # See .github/actions/setup-java/action.yml to update Java version
+      - name: Set up Java
+        uses: ./.github/actions/setup-java
 
       - name: Generate nightly version
         id: version

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -125,13 +125,6 @@ on:
         type: boolean
         default: false
 
-# Global environment settings used across jobs
-# - JAVA_VERSION: version of JDK used to build the project
-# - JAVA_DISTRIBUTION: OpenJDK distribution to install via actions/setup-java
-env:
-  JAVA_VERSION: '25'
-  JAVA_DISTRIBUTION: 'temurin'
-
 jobs:
   validate-release:
     name: Validate Release Prerequisites
@@ -187,15 +180,10 @@ jobs:
         with:
           ref: "v${{ inputs.release_version }}-${{ inputs.release_candidate }}"
 
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          cache: 'gradle'
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      # Set up Java environment using centralized configuration
+      # See .github/actions/setup-java/action.yml to update Java version
+      - name: Set up Java
+        uses: ./.github/actions/setup-java
 
       - name: Update version in build.gradle.kts
         run: |


### PR DESCRIPTION
## Summary
- Create a reusable composite action (`.github/actions/setup-java`) to centralize Java version configuration
- Update all workflows to use the composite action instead of inline setup-java steps
- Eliminate duplicate `env:` variables and `chmod +x gradlew` steps across workflows

## Changes
- **New file**: `.github/actions/setup-java/action.yml` - Composite action with Java 25 + Temurin + Gradle cache
- **Updated workflows**:
  - `build-and-publish.yml`
  - `release-publish.yml`
  - `nightly-build.yml`
  - `atr-release.yml`
  - `atr-release-test.yml`

## Benefits
- **Single-point updates**: To change Java version, modify only `.github/actions/setup-java/action.yml`
- **Reduced duplication**: Eliminates repeated `JAVA_VERSION`, `JAVA_DISTRIBUTION` env vars
- **Consistent setup**: All workflows now use identical Java configuration
- **Cleaner workflows**: Removed redundant `chmod +x gradlew` steps (now in composite action)

## Test plan
- [ ] Verify build-and-publish workflow runs successfully
- [ ] Verify composite action properly sets up Java 25 with Temurin
- [ ] Verify Gradle caching still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)