### PR TITLE
feat(security): add configurable security bypass for HTTP mode

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/config/MethodSecurityConfiguration.java
+++ b/src/main/java/org/apache/solr/mcp/server/config/MethodSecurityConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.mcp.server.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * Configuration class that enables method-level security only when
+ * spring.security.enabled=true (or not set).
+ *
+ * <p>
+ * This allows the application to run without authentication when
+ * spring.security.enabled=false, bypassing @PreAuthorize annotations.
+ */
+@Profile("http")
+@Configuration
+@ConditionalOnProperty(name = "spring.security.enabled", havingValue = "true", matchIfMissing = true)
+@EnableMethodSecurity
+class MethodSecurityConfiguration {
+}

--- a/src/main/java/org/apache/solr/mcp/server/metadata/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/metadata/CollectionService.java
@@ -16,7 +16,16 @@
  */
 package org.apache.solr.mcp.server.metadata;
 
+import static org.apache.solr.mcp.server.metadata.CollectionUtils.getFloat;
+import static org.apache.solr.mcp.server.metadata.CollectionUtils.getInteger;
+import static org.apache.solr.mcp.server.metadata.CollectionUtils.getLong;
+import static org.apache.solr.mcp.server.util.JsonUtils.toJson;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -40,16 +49,6 @@ import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.stereotype.Service;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import static org.apache.solr.mcp.server.metadata.CollectionUtils.getFloat;
-import static org.apache.solr.mcp.server.metadata.CollectionUtils.getInteger;
-import static org.apache.solr.mcp.server.metadata.CollectionUtils.getLong;
-import static org.apache.solr.mcp.server.util.JsonUtils.toJson;
 
 /**
  * Spring Service providing comprehensive Solr collection management and

--- a/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
+++ b/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
@@ -16,6 +16,8 @@
  */
 package org.apache.solr.mcp.server.metadata;
 
+import static org.apache.solr.mcp.server.util.JsonUtils.toJson;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
@@ -23,8 +25,6 @@ import org.apache.solr.client.solrj.response.schema.SchemaRepresentation;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springframework.stereotype.Service;
-
-import static org.apache.solr.mcp.server.util.JsonUtils.toJson;
 
 /**
  * Spring Service providing schema introspection and management capabilities for

--- a/src/main/resources/application-http.properties
+++ b/src/main/resources/application-http.properties
@@ -8,3 +8,5 @@ spring.ai.mcp.server.stdio=false
 # For Keycloak: https://<keycloak-host>/realms/<realm-name>
 # For Okta: https://<your-okta-domain>/oauth2/default/.well-known/openid-configuration
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${OAUTH2_ISSUER_URI:https://your-auth0-domain.auth0.com/}
+# Security toggle - set to true to enable OAuth2 authentication, false to bypass
+spring.security.enabled=${SECURITY_ENABLED:false}


### PR DESCRIPTION
## Summary

Add ability to disable OAuth2 security in HTTP mode for local development and testing scenarios. Security can be toggled via `spring.security.enabled` property:

- `spring.security.enabled=true` (or unset): Full OAuth2 authentication with `@PreAuthorize` enforcement
- `spring.security.enabled=false`: All requests permitted, `@PreAuthorize` annotations bypassed

## Changes

- **McpServerConfiguration.java**: Add `@ConditionalOnProperty` to `SecurityFilterChain` beans; add new `unsecured()` filter chain
- **MethodSecurityConfiguration.java**: New file - extracts `@EnableMethodSecurity` to separate class that's conditionally loaded
- **application-http.properties**: Add `spring.security.enabled=${SECURITY_ENABLED:false}` property (defaults to disabled for easier local testing)

## Usage

To enable security:
```bash
export SECURITY_ENABLED=true
export OAUTH2_ISSUER_URI=https://your-tenant.auth0.com/
./gradlew bootRun
```

To disable security (default):
```bash
./gradlew bootRun
```

## Test plan

- [ ] Run `./gradlew build` - verify tests pass
- [ ] Run with `PROFILES=http` and verify MCP Inspector works without auth token
- [ ] Run with `PROFILES=http SECURITY_ENABLED=true OAUTH2_ISSUER_URI=...` and verify auth is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)