### PR TITLE
feat: change MCP server protocol from streamable to stateless

### DIFF
--- a/src/main/resources/application-http.properties
+++ b/src/main/resources/application-http.properties
@@ -1,6 +1,6 @@
 spring.main.web-application-type=servlet
 spring.ai.mcp.server.type=sync
-spring.ai.mcp.server.protocol=streamable
+spring.ai.mcp.server.protocol=stateless
 spring.ai.mcp.server.stdio=false
 # OAuth2 Security Configuration
 # Configure the issuer URI for your OAuth2 authorization server


### PR DESCRIPTION
Stateless Streamable-HTTP MCP servers are designed for simplified deployments where session state is not maintained between requests. These servers are ideal for microservices architectures and cloud-native deployments.
The stateless servers don’t support message requests to the MCP client (e.g., elicitation, sampling, ping). 

This change should be merged once https://github.com/spring-projects/spring-ai/issues/5133 is merged.