### PR TITLE
fix: standardize MCP tool names to kebab-case

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
@@ -192,7 +192,7 @@ public class IndexingService {
 	 * @see #indexDocuments(String, List)
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "index_json_documents", description = "Index documents from json String into Solr collection")
+	@McpTool(name = "index-json-documents", description = "Index documents from json String into Solr collection")
 	public void indexJsonDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "JSON string containing documents to index") String json)
 			throws IOException, SolrServerException {
@@ -258,7 +258,7 @@ public class IndexingService {
 	 * @see #indexDocuments(String, List)
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "index_csv_documents", description = "Index documents from CSV string into Solr collection")
+	@McpTool(name = "index-csv-documents", description = "Index documents from CSV string into Solr collection")
 	public void indexCsvDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "CSV string containing documents to index") String csv)
 			throws IOException, SolrServerException {
@@ -348,7 +348,7 @@ public class IndexingService {
 	 * @see #indexDocuments(String, List)
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "index_xml_documents", description = "Index documents from XML string into Solr collection")
+	@McpTool(name = "index-xml-documents", description = "Index documents from XML string into Solr collection")
 	public void indexXmlDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "XML string containing documents to index") String xml)
 			throws ParserConfigurationException, SAXException, IOException, SolrServerException {

--- a/src/main/java/org/apache/solr/mcp/server/metadata/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/metadata/CollectionService.java
@@ -342,7 +342,7 @@ public class CollectionService {
 	 * @see CollectionAdminRequest.List
 	 * @see CoreAdminRequest
 	 */
-	@McpTool(description = "List solr collections")
+	@McpTool(name = "list-collections", description = "List solr collections")
 	public List<String> listCollections() {
 		try {
 			if (solrClient instanceof CloudSolrClient) {
@@ -431,7 +431,7 @@ public class CollectionService {
 	 * @see LukeRequest
 	 * @see #extractCollectionName(String)
 	 */
-	@McpTool(description = "Get stats/metrics on a Solr collection")
+	@McpTool(name = "get-collection-stats", description = "Get stats/metrics on a Solr collection")
 	public SolrMetrics getCollectionStats(
 			@McpToolParam(description = "Solr collection to get stats/metrics for") String collection)
 			throws SolrServerException, IOException {
@@ -1022,7 +1022,7 @@ public class CollectionService {
 	 * @see SolrHealthStatus
 	 * @see SolrPingResponse
 	 */
-	@McpTool(description = "Check health of a Solr collection")
+	@McpTool(name = "check-health", description = "Check health of a Solr collection")
 	public SolrHealthStatus checkHealth(@McpToolParam(description = "Solr collection") String collection) {
 		try {
 			// Ping Solr

--- a/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
+++ b/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
@@ -249,7 +249,7 @@ public class SchemaService {
 	 * @see SchemaRequest
 	 * @see org.apache.solr.client.solrj.response.schema.SchemaResponse
 	 */
-	@McpTool(description = "Get schema for a Solr collection")
+	@McpTool(name = "get-schema", description = "Get schema for a Solr collection")
 	public SchemaRepresentation getSchema(String collection) throws Exception {
 		SchemaRequest schemaRequest = new SchemaRequest();
 		return schemaRequest.process(solrClient, collection).getSchemaRepresentation();

--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -215,7 +215,7 @@ public class SearchService {
 	 *             If there's an I/O error
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "Search", description = """
+	@McpTool(name = "search", description = """
 			Search specified Solr collection with query, optional filters, facets, sorting, and pagination.
 			Note that solr has dynamic fields where name of field in schema may end with suffixes
 			_s: Represents a string field, used for exact string matching.

--- a/src/test/java/org/apache/solr/mcp/server/McpToolRegistrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/McpToolRegistrationTest.java
@@ -49,7 +49,7 @@ class McpToolRegistrationTest {
 
 		// Verify the annotation properties
 		McpTool toolAnnotation = searchMethod.getAnnotation(McpTool.class);
-		assertEquals("Search", toolAnnotation.name(), "McpTool name should be 'Search'");
+		assertEquals("search", toolAnnotation.name(), "McpTool name should be 'search' (kebab-case)");
 		assertNotNull(toolAnnotation.description(), "McpTool description should not be null");
 		assertFalse(toolAnnotation.description().isBlank(), "McpTool description should not be blank");
 	}

--- a/src/test/java/org/apache/solr/mcp/server/SampleClient.java
+++ b/src/test/java/org/apache/solr/mcp/server/SampleClient.java
@@ -158,8 +158,9 @@ public class SampleClient {
 			assertEquals(8, toolsList.tools().size(), "Expected 8 tools to be available");
 
 			// Define expected tools based on the log output
-			Set<String> expectedToolNames = Set.of("index_json_documents", "index_csv_documents", "getCollectionStats",
-					"Search", "listCollections", "checkHealth", "index_xml_documents", "getSchema");
+			Set<String> expectedToolNames = Set.of("index-json-documents", "index-csv-documents",
+					"get-collection-stats", "search", "list-collections", "check-health", "index-xml-documents",
+					"get-schema");
 
 			// Validate each expected tool is present
 			List<String> actualToolNames = toolsList.tools().stream().map(Tool::name).toList();
@@ -179,23 +180,23 @@ public class SampleClient {
 
 				// Validate specific tools based on expected behavior
 				switch (tool.name()) {
-					case "index_json_documents" :
+					case "index-json-documents" :
 						assertTrue(tool.description().toLowerCase().contains("json"),
 								"JSON indexing tool should mention JSON in" + " description");
 						break;
-					case "index_csv_documents" :
+					case "index-csv-documents" :
 						assertTrue(tool.description().toLowerCase().contains("csv"),
 								"CSV indexing tool should mention CSV in" + " description");
 						break;
-					case "Search" :
+					case "search" : // single word, no hyphen needed
 						assertTrue(tool.description().toLowerCase().contains("search"),
 								"Search tool should mention search in description");
 						break;
-					case "listCollections" :
+					case "list-collections" :
 						assertTrue(tool.description().toLowerCase().contains("collection"),
 								"List collections tool should mention collections" + " in description");
 						break;
-					case "checkHealth" :
+					case "check-health" :
 						assertTrue(tool.description().toLowerCase().contains("health"),
 								"Health check tool should mention health in" + " description");
 						break;


### PR DESCRIPTION
## Summary

- Standardize all `@McpTool` `name` attributes to use kebab-case for consistency across the project
- Add explicit `name` attributes to tools that were relying on the Java method name default (camelCase)
- Lowercase the `Search` tool name to `search`

| Tool | Before | After |
|------|--------|-------|
| search | `Search` | `search` |
| list collections | `listCollections` (default) | `list-collections` |
| get collection stats | `getCollectionStats` (default) | `get-collection-stats` |
| check health | `checkHealth` (default) | `check-health` |
| get schema | `getSchema` (default) | `get-schema` |
| index JSON | `index_json_documents` | `index-json-documents` |
| index CSV | `index_csv_documents` | `index-csv-documents` |
| index XML | `index_xml_documents` | `index-xml-documents` |

## Test plan

- [x] `./gradlew build` passes with all tests green
- [x] Updated `McpToolRegistrationTest` to assert new names
- [x] Updated `SampleClient` expected tool names and switch cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)