### PR TITLE
chore(deps): bump Spring AI from 1.1.3 to 1.1.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ jib = "3.4.5"
 spotless = "7.0.2"
 
 # Main dependencies
-spring-ai = "1.1.3"
+spring-ai = "1.1.4"
 solr = "10.0.0"
 commons-csv = "1.10.0"
 jspecify = "1.0.0"


### PR DESCRIPTION
## Summary
- Bumps Spring AI from 1.1.3 to 1.1.4 (patch release)

## Test plan
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)