### PR TITLE
chore(deps): bump Jib from 3.4.5 to 3.5.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 spring-boot = "3.5.11"
 spring-dependency-management = "1.1.7"
 errorprone-plugin = "4.2.0"
-jib = "3.4.5"
+jib = "3.5.3"
 spotless = "7.0.2"
 
 # Main dependencies


### PR DESCRIPTION
## Summary
- Bumps Jib Gradle plugin from 3.4.5 to 3.5.3 (minor release)

## Test plan
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)