### PR TITLE
chore(deps): bump Commons CSV from 1.10.0 to 1.14.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ spotless = "7.0.2"
 # Main dependencies
 spring-ai = "1.1.3"
 solr = "10.0.0"
-commons-csv = "1.10.0"
+commons-csv = "1.14.1"
 jspecify = "1.0.0"
 mcp-server-security = "0.0.4"
 


### PR DESCRIPTION
## Summary
- Bumps Apache Commons CSV from 1.10.0 to 1.14.1

## Test plan
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)