### PR TITLE
chore(deps): bump NullAway from 0.12.7 to 0.13.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ mcp-server-security = "0.0.4"
 
 # Error Prone and analysis tools
 errorprone-core = "2.38.0"
-nullaway = "0.12.7"
+nullaway = "0.13.1"
 
 
 # Test dependencies


### PR DESCRIPTION
## Summary
- Bumps NullAway from 0.12.7 to 0.13.1

## Test plan
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)