### PR TITLE
chore(deps): bump OpenTelemetry Instrumentation BOM from 2.11.0 to 2.26.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.4
+- **Framework:** Spring Boot 3.5.8, Spring AI 1.1.2
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ nullaway = "0.12.7"
 # Test dependencies
 testcontainers = "1.21.3"
 awaitility = "4.2.2"
-opentelemetry-instrumentation-bom = "2.11.0"
+opentelemetry-instrumentation-bom = "2.26.1"
 
 [libraries]
 # Spring


### PR DESCRIPTION
## Summary
- Bumps OpenTelemetry Instrumentation BOM from 2.11.0 to 2.26.1
- Includes fix for CVE-2026-33701 (unsafe deserialization in RMI instrumentation)

## Test plan
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)