### PR TITLE
fix(config): accept text/plain content-type in JsonResponseParser

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/config/JsonResponseParser.java
+++ b/src/main/java/org/apache/solr/mcp/server/config/JsonResponseParser.java
@@ -81,7 +81,10 @@ class JsonResponseParser extends ResponseParser {
 
 	@Override
 	public Collection<String> getContentTypes() {
-		return List.of(MediaType.APPLICATION_JSON_VALUE);
+		// Some Solr endpoints (notably /admin/ping and some standalone-mode handlers)
+		// return JSON-encoded bodies with Content-Type: text/plain. Accept it so SolrJ
+		// does not reject otherwise-valid responses.
+		return List.of(MediaType.APPLICATION_JSON_VALUE, MediaType.TEXT_PLAIN_VALUE);
 	}
 
 	@Override

--- a/src/test/java/org/apache/solr/mcp/server/config/JsonResponseParserContentTypesTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/config/JsonResponseParserContentTypesTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.mcp.server.config;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+/**
+ * Unit tests verifying the Content-Types accepted by
+ * {@link JsonResponseParser}.
+ *
+ * <p>
+ * Some Solr request handlers (notably {@code /admin/ping} and certain
+ * standalone-mode paths) return JSON-encoded bodies with Content-Type
+ * {@code text/plain} rather than {@code application/json}. SolrJ rejects the
+ * response unless the configured
+ * {@link org.apache.solr.client.solrj.response.ResponseParser} advertises that
+ * Content-Type, so the parser must tolerate both.
+ */
+class JsonResponseParserContentTypesTest {
+
+	@Test
+	void advertisesJsonAndTextPlain() {
+		JsonResponseParser parser = new JsonResponseParser(new ObjectMapper());
+
+		Collection<String> contentTypes = parser.getContentTypes();
+
+		assertTrue(contentTypes.contains(MediaType.APPLICATION_JSON_VALUE),
+				"Parser must advertise application/json so SolrJ accepts standard Solr responses");
+		assertTrue(contentTypes.contains(MediaType.TEXT_PLAIN_VALUE),
+				"Parser must advertise text/plain so SolrJ accepts responses from handlers that mislabel JSON bodies");
+	}
+}


### PR DESCRIPTION
> Split out from #89 at maintainer's request — this PR contains only the Content-Type tolerance fix.

## Summary

Widens `JsonResponseParser#getContentTypes()` to advertise both `application/json` and `text/plain`, so SolrJ stops rejecting otherwise-valid JSON responses that are served with `Content-Type: text/plain`.

## Motivation

Some Solr request handlers (notably `/admin/ping` and a number of standalone-mode paths) return JSON-encoded bodies with `Content-Type: text/plain`. SolrJ validates the response Content-Type against the set advertised by the configured `ResponseParser` and fails with:

```
Expected mime type in [application/json] but got text/plain
```

…even though the payload is a valid Solr JSON response. This surfaces to MCP clients through tools like `check-health` and `search` as errors, despite the underlying query succeeding.

Observed end-to-end against a real standalone Solr 9.x instance: `check-health` and `search` both return the error above pre-fix, and return clean results post-fix.

## Changes

- `JsonResponseParser#getContentTypes`: advertise `application/json` **and** `text/plain`.
- No behavioural change for handlers that already return `application/json`.

## Tests

- `JsonResponseParserContentTypesTest` (new): pins the advertised Content-Type set.
- `./gradlew build` passes locally (Spotless + NullAway + full unit suite).

## Test plan

- [x] `./gradlew spotlessCheck`
- [x] `./gradlew build` (unit tests)
- [x] Manual end-to-end against a standalone Solr 9.x — `check-health` and `search` now succeed on handlers that previously returned `text/plain`.

## Notes

- No new runtime dependencies.
- Behaviour is strictly additive (accepting one more Content-Type).
- Signed off under DCO; commit follows Conventional Commits per `CONTRIBUTING.md`.

Companion PR for the Basic Auth feature: #89

Co-authored-by: Claude <noreply@anthropic.com>