### PR TITLE
fix: make Main.main() public

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/Main.java
+++ b/src/main/java/org/apache/solr/mcp/server/Main.java
@@ -105,7 +105,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  */
 @SpringBootApplication
 public class Main {
-	static void main(String[] args) {
+	public static void main(String[] args) {
 		SpringApplication.run(Main.class, args);
 	}
 }


### PR DESCRIPTION
## Summary
- Make `Main.main()` public instead of package-private for conventional JVM entry point visibility

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)