### PR TITLE
fix: add explicit destroyMethod to SolrClient bean

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/config/SolrConfig.java
+++ b/src/main/java/org/apache/solr/mcp/server/config/SolrConfig.java
@@ -171,7 +171,7 @@ public class SolrConfig {
 		return new JsonResponseParser(objectMapper);
 	}
 
-	@Bean
+	@Bean(destroyMethod = "close")
 	SolrClient solrClient(SolrConfigurationProperties properties, JsonResponseParser jsonResponseParser) {
 		String url = properties.url();
 


### PR DESCRIPTION
## Summary
- Add explicit `@Bean(destroyMethod = "close")` to SolrClient bean to ensure HTTP connections are properly released on shutdown

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)