### PR TITLE
fix: use ObjectMapper for error JSON in SchemaService

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
+++ b/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
@@ -20,6 +20,7 @@ import static org.apache.solr.mcp.server.util.JsonUtils.toJson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.observation.annotation.Observed;
+import java.util.Map;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.schema.SchemaRepresentation;
@@ -166,7 +167,7 @@ public class SchemaService {
 		try {
 			return toJson(objectMapper, getSchema(collection));
 		} catch (Exception e) {
-			return "{\"error\": \"" + e.getMessage() + "\"}";
+			return toJson(objectMapper, Map.of("error", e.getMessage()));
 		}
 	}
 

--- a/src/main/java/org/apache/solr/mcp/server/schema/SchemaService.java
+++ b/src/main/java/org/apache/solr/mcp/server/schema/SchemaService.java
@@ -185,7 +185,7 @@ public class SchemaService {
 		try {
 			return toJson(objectMapper, getSchema(collection));
 		} catch (Exception e) {
-			return "{\"error\": \"" + e.getMessage() + "\"}";
+			return toJson(objectMapper, Map.of("error", e.getMessage()));
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Replace string interpolation of `e.getMessage()` in `getSchemaResource()` with proper ObjectMapper serialization to prevent JSON injection from exception messages containing special characters

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)