### PR TITLE
fix: inject Spring ObjectMapper in JsonDocumentCreator

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/indexing/documentcreator/JsonDocumentCreator.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/documentcreator/JsonDocumentCreator.java
@@ -41,6 +41,12 @@ public class JsonDocumentCreator implements SolrDocumentCreator {
 
 	private static final int MAX_INPUT_SIZE_BYTES = 10 * 1024 * 1024;
 
+	private final ObjectMapper objectMapper;
+
+	public JsonDocumentCreator(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
 	/**
 	 * Creates a list of schema-less SolrInputDocument objects from a JSON string.
 	 *
@@ -111,8 +117,7 @@ public class JsonDocumentCreator implements SolrDocumentCreator {
 		List<SolrInputDocument> documents = new ArrayList<>();
 
 		try {
-			ObjectMapper mapper = new ObjectMapper();
-			JsonNode rootNode = mapper.readTree(json);
+			JsonNode rootNode = this.objectMapper.readTree(json);
 
 			if (rootNode.isArray()) {
 				for (JsonNode item : rootNode) {

--- a/src/main/java/org/apache/solr/mcp/server/indexing/documentcreator/SolrDocumentCreator.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/documentcreator/SolrDocumentCreator.java
@@ -56,7 +56,7 @@ import org.apache.solr.common.SolrInputDocument;
  * <strong>Usage Example:</strong>
  *
  * <pre>{@code
- * SolrDocumentCreator creator = new JsonDocumentCreator();
+ * SolrDocumentCreator creator = new JsonDocumentCreator(new ObjectMapper());
  * String jsonData = "[{\"title\":\"Document 1\",\"content\":\"Content here\"}]";
  * List<SolrInputDocument> documents = creator.create(jsonData);
  * }</pre>

--- a/src/test/java/org/apache/solr/mcp/server/indexing/IndexingServiceIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/indexing/IndexingServiceIntegrationTest.java
@@ -72,7 +72,8 @@ class IndexingServiceIntegrationTest {
 		// Boot test
 		XmlDocumentCreator xmlDocumentCreator = new XmlDocumentCreator();
 		CsvDocumentCreator csvDocumentCreator = new CsvDocumentCreator();
-		JsonDocumentCreator jsonDocumentCreator = new JsonDocumentCreator();
+		JsonDocumentCreator jsonDocumentCreator = new JsonDocumentCreator(
+				new com.fasterxml.jackson.databind.ObjectMapper());
 
 		indexingDocumentCreator = new IndexingDocumentCreator(xmlDocumentCreator, csvDocumentCreator,
 				jsonDocumentCreator);


### PR DESCRIPTION
## Summary
- Replace per-call `new ObjectMapper()` allocation in `JsonDocumentCreator.create()` with Spring-injected instance for better performance and configuration consistency

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)