### PR TITLE
fix: tighten CORS to localhost by default with configurable origins

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
+++ b/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.mcp.server.security;
 
+import java.util.Arrays;
 import java.util.List;
 import org.springaicommunity.mcp.security.server.config.McpServerOAuth2Configurer;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,6 +39,13 @@ class HttpSecurityConfiguration {
 
 	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:}")
 	private String issuerUrl;
+
+	// Defaults to localhost patterns so MCP Inspector (which runs on localhost with
+	// various ports) works out of the box. Override via
+	// http.cors.allowed-origin-patterns
+	// to add additional origins (e.g., for remote MCP clients).
+	@Value("${http.cors.allowed-origin-patterns:http://localhost:*,https://localhost:*,http://127.0.0.1:*,https://127.0.0.1:*}")
+	private String allowedOriginPatterns;
 
 	@Bean
 	@ConditionalOnProperty(name = "http.security.enabled", havingValue = "true", matchIfMissing = true)
@@ -69,7 +77,8 @@ class HttpSecurityConfiguration {
 
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOriginPatterns(List.of("*"));
+		configuration
+				.setAllowedOriginPatterns(Arrays.stream(allowedOriginPatterns.split(",")).map(String::trim).toList());
 		configuration.setAllowedMethods(List.of("*"));
 		configuration.setAllowedHeaders(List.of("*"));
 		configuration.setAllowCredentials(true);

--- a/src/main/resources/application-http.properties
+++ b/src/main/resources/application-http.properties
@@ -13,6 +13,9 @@ spring.docker.compose.enabled=true
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${OAUTH2_ISSUER_URI:https://your-auth0-domain.auth0.com/}
 # Security toggle - set to true to enable OAuth2 authentication, false to bypass
 http.security.enabled=${HTTP_SECURITY_ENABLED:false}
+# CORS allowed origin patterns (comma-separated). Defaults to localhost to support
+# MCP Inspector. Add additional origins for remote MCP clients as needed.
+http.cors.allowed-origin-patterns=${CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:*,https://localhost:*,http://127.0.0.1:*,https://127.0.0.1:*}
 # observability
 management.endpoints.web.exposure.include=health,sbom,metrics,info,loggers,prometheus
 # Enable @Observed annotation support for custom spans


### PR DESCRIPTION
## Summary
- Replace wildcard CORS origin pattern (`*`) with localhost defaults (`http://localhost:*`, `https://localhost:*`, `http://127.0.0.1:*`, `https://127.0.0.1:*`)
- Add configurable `http.cors.allowed-origin-patterns` property (also settable via `CORS_ALLOWED_ORIGIN_PATTERNS` env var) for customization
- MCP Inspector continues to work out of the box on localhost

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] MCP Inspector on localhost still works with default config
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)