### PR TITLE
refactor: reduce CollectionService internal method visibility

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -464,7 +464,7 @@ public class CollectionService {
 	 * @see IndexStats
 	 * @see LukeResponse
 	 */
-	public IndexStats buildIndexStats(LukeResponse lukeResponse) {
+	IndexStats buildIndexStats(LukeResponse lukeResponse) {
 		NamedList<Object> indexInfo = lukeResponse.getIndexInfo();
 
 		// Extract index information using helper methods
@@ -505,7 +505,7 @@ public class CollectionService {
 	 * @see QueryStats
 	 * @see QueryResponse
 	 */
-	public QueryStats buildQueryStats(QueryResponse response) {
+	QueryStats buildQueryStats(QueryResponse response) {
 
 		return new QueryStats(response.getQTime(), response.getResults().getNumFound(),
 				response.getResults().getStart(), response.getResults().getMaxScore());
@@ -556,7 +556,7 @@ public class CollectionService {
 	 * @see #extractCacheStats(NamedList)
 	 * @see #isCacheStatsEmpty(CacheStats)
 	 */
-	public CacheStats getCacheMetrics(String collection) {
+	CacheStats getCacheMetrics(String collection) {
 		String actualCollection = extractCollectionName(collection);
 
 		if (!validateCollectionExists(actualCollection)) {
@@ -668,7 +668,7 @@ public class CollectionService {
 	 * @see #fetchFlatHandlerInfo(String, String, String)
 	 * @see #isHandlerStatsEmpty(HandlerStats)
 	 */
-	public HandlerStats getHandlerMetrics(String collection) {
+	HandlerStats getHandlerMetrics(String collection) {
 		String actualCollection = extractCollectionName(collection);
 
 		if (!validateCollectionExists(actualCollection)) {

--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -573,7 +573,7 @@ public class CollectionService {
 	 * @see IndexStats
 	 * @see LukeResponse
 	 */
-	public IndexStats buildIndexStats(LukeResponse lukeResponse) {
+	IndexStats buildIndexStats(LukeResponse lukeResponse) {
 		NamedList<Object> indexInfo = lukeResponse.getIndexInfo();
 
 		// Extract index information using helper methods
@@ -614,7 +614,7 @@ public class CollectionService {
 	 * @see QueryStats
 	 * @see QueryResponse
 	 */
-	public QueryStats buildQueryStats(QueryResponse response) {
+	QueryStats buildQueryStats(QueryResponse response) {
 
 		return new QueryStats(response.getQTime(), response.getResults().getNumFound(),
 				response.getResults().getStart(), response.getResults().getMaxScore());
@@ -669,7 +669,7 @@ public class CollectionService {
 	 * @see #extractCacheStats(NamedList)
 	 * @see #isCacheStatsEmpty(CacheStats)
 	 */
-	public @Nullable CacheStats getCacheMetrics(String collection) throws SolrServerException, IOException {
+	@Nullable CacheStats getCacheMetrics(String collection) throws SolrServerException, IOException {
 		String actualCollection = extractCollectionName(collection);
 
 		if (!validateCollectionExists(actualCollection)) {
@@ -785,7 +785,7 @@ public class CollectionService {
 	 * @see #fetchFlatHandlerInfo(String, String, String)
 	 * @see #isHandlerStatsEmpty(HandlerStats)
 	 */
-	public @Nullable HandlerStats getHandlerMetrics(String collection) throws SolrServerException, IOException {
+	@Nullable HandlerStats getHandlerMetrics(String collection) throws SolrServerException, IOException {
 		String actualCollection = extractCollectionName(collection);
 
 		if (!validateCollectionExists(actualCollection)) {


### PR DESCRIPTION
## Summary
- `buildIndexStats()`, `buildQueryStats()`, `getCacheMetrics()`, `getHandlerMetrics()` go from public to package-private. They are internal to `CollectionService`; every caller lives in `org.apache.solr.mcp.server.collection`, production and test alike (`CollectionServiceTest`, `CollectionServiceIntegrationTest`), so the narrowing costs no test access. `getCacheMetrics`/`getHandlerMetrics` keep their `@Nullable`.

## Verification
- `./gradlew build` and `./gradlew nativeTest -Pnative` pass; no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
