### PR TITLE
fix: return indexing results to MCP clients

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
@@ -193,11 +193,13 @@ public class IndexingService {
 	 */
 	@PreAuthorize("isAuthenticated()")
 	@McpTool(name = "index-json-documents", description = "Index documents from json String into Solr collection")
-	public void indexJsonDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
+	public String indexJsonDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "JSON string containing documents to index") String json)
 			throws IOException, SolrServerException {
 		List<SolrInputDocument> schemalessDoc = indexingDocumentCreator.createSchemalessDocumentsFromJson(json);
-		indexDocuments(collection, schemalessDoc);
+		int successCount = indexDocuments(collection, schemalessDoc);
+		return "Successfully indexed " + successCount + " of " + schemalessDoc.size() + " documents into collection '"
+				+ collection + "'";
 	}
 
 	/**
@@ -259,11 +261,13 @@ public class IndexingService {
 	 */
 	@PreAuthorize("isAuthenticated()")
 	@McpTool(name = "index-csv-documents", description = "Index documents from CSV string into Solr collection")
-	public void indexCsvDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
+	public String indexCsvDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "CSV string containing documents to index") String csv)
 			throws IOException, SolrServerException {
 		List<SolrInputDocument> schemalessDoc = indexingDocumentCreator.createSchemalessDocumentsFromCsv(csv);
-		indexDocuments(collection, schemalessDoc);
+		int successCount = indexDocuments(collection, schemalessDoc);
+		return "Successfully indexed " + successCount + " of " + schemalessDoc.size() + " documents into collection '"
+				+ collection + "'";
 	}
 
 	/**
@@ -349,11 +353,13 @@ public class IndexingService {
 	 */
 	@PreAuthorize("isAuthenticated()")
 	@McpTool(name = "index-xml-documents", description = "Index documents from XML string into Solr collection")
-	public void indexXmlDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
+	public String indexXmlDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "XML string containing documents to index") String xml)
 			throws ParserConfigurationException, SAXException, IOException, SolrServerException {
 		List<SolrInputDocument> schemalessDoc = indexingDocumentCreator.createSchemalessDocumentsFromXml(xml);
-		indexDocuments(collection, schemalessDoc);
+		int successCount = indexDocuments(collection, schemalessDoc);
+		return "Successfully indexed " + successCount + " of " + schemalessDoc.size() + " documents into collection '"
+				+ collection + "'";
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Change `indexJsonDocuments()`, `indexCsvDocuments()`, and `indexXmlDocuments()` from `void` to `String` return type
- Return success/total count message so the AI client knows how many documents were actually indexed
- Prevents silent data loss where partial indexing failures go unreported

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)