### PR TITLE
fix: add JSpecify @Nullable annotations to SearchService parameters

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/search/SearchResponse.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchResponse.java
@@ -18,6 +18,7 @@ package org.apache.solr.mcp.server.search;
 
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Immutable record representing a structured search response from Apache Solr
@@ -134,6 +135,6 @@ import java.util.Map;
  * @see org.apache.solr.client.solrj.response.QueryResponse
  * @see org.apache.solr.common.SolrDocumentList
  */
-public record SearchResponse(long numFound, long start, Float maxScore, List<Map<String, Object>> documents,
+public record SearchResponse(long numFound, long start, @Nullable Float maxScore, List<Map<String, Object>> documents,
 		Map<String, Map<String, Long>> facets) {
 }

--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -30,6 +30,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.FacetParams;
+import org.jspecify.annotations.Nullable;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -242,12 +243,12 @@ public class SearchService {
 			    }
 			""")
 	public SearchResponse search(@McpToolParam(description = "Solr collection to query") String collection,
-			@McpToolParam(description = "Solr q parameter. If none specified defaults to \"*:*\"", required = false) String query,
-			@McpToolParam(description = "Solr fq parameter", required = false) List<String> filterQueries,
-			@McpToolParam(description = "Solr facet fields", required = false) List<String> facetFields,
-			@McpToolParam(description = "Solr sort parameter", required = false) List<Map<String, String>> sortClauses,
-			@McpToolParam(description = "Starting offset for pagination", required = false) Integer start,
-			@McpToolParam(description = "Number of rows to return", required = false) Integer rows)
+			@McpToolParam(description = "Solr q parameter. If none specified defaults to \"*:*\"", required = false) @Nullable String query,
+			@McpToolParam(description = "Solr fq parameter", required = false) @Nullable List<String> filterQueries,
+			@McpToolParam(description = "Solr facet fields", required = false) @Nullable List<String> facetFields,
+			@McpToolParam(description = "Solr sort parameter", required = false) @Nullable List<Map<String, String>> sortClauses,
+			@McpToolParam(description = "Starting offset for pagination", required = false) @Nullable Integer start,
+			@McpToolParam(description = "Number of rows to return", required = false) @Nullable Integer rows)
 			throws SolrServerException, IOException {
 
 		// query

--- a/src/main/java/org/apache/solr/mcp/server/search/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.search;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/search/SearchServiceIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/search/SearchServiceIntegrationTest.java
@@ -194,7 +194,9 @@ class SearchServiceIntegrationTest {
 		List<Map<String, Object>> documents = result.documents();
 		assertEquals(1, documents.size());
 		Map<String, Object> book = documents.getFirst();
-		assertEquals("A Game of Thrones", ((List<?>) book.get("name")).getFirst());
+		List<?> nameField = (List<?>) book.get("name");
+		assertNotNull(nameField);
+		assertEquals("A Game of Thrones", nameField.getFirst());
 	}
 
 	@Test
@@ -205,7 +207,9 @@ class SearchServiceIntegrationTest {
 		List<Map<String, Object>> documents = result.documents();
 		assertEquals(3, documents.size());
 		Map<String, Object> book = documents.getFirst();
-		assertEquals("George R.R. Martin", ((List<?>) book.get("author_ss")).getFirst());
+		List<?> authorField = (List<?>) book.get("author_ss");
+		assertNotNull(authorField);
+		assertEquals("George R.R. Martin", authorField.getFirst());
 	}
 
 	@Test
@@ -224,9 +228,9 @@ class SearchServiceIntegrationTest {
 		List<Map<String, Object>> documents = result.documents();
 		assertFalse(documents.isEmpty());
 		Map<String, Object> book = documents.getFirst();
-		double currentPrice = ((List<?>) book.get("price")).isEmpty()
-				? 0.0
-				: ((Number) ((List<?>) book.get("price")).getFirst()).doubleValue();
+		List<?> priceField = (List<?>) book.get("price");
+		assertNotNull(priceField);
+		double currentPrice = priceField.isEmpty() ? 0.0 : ((Number) priceField.getFirst()).doubleValue();
 		assertTrue(currentPrice > 0);
 	}
 
@@ -277,7 +281,9 @@ class SearchServiceIntegrationTest {
 		assertFalse(documents.isEmpty());
 		int previousSequence = 0;
 		for (Map<String, Object> book : documents) {
-			int currentSequence = ((Number) book.get("sequence_i")).intValue();
+			Number sequenceValue = (Number) book.get("sequence_i");
+			assertNotNull(sequenceValue);
+			int currentSequence = sequenceValue.intValue();
 			assertTrue(currentSequence >= previousSequence, "Books should be sorted by sequence_i in ascending order");
 			previousSequence = currentSequence;
 		}


### PR DESCRIPTION
## Summary
- Add `@Nullable` annotations to optional parameters in `SearchService.search()` (`query`, `filterQueries`, `facetFields`, `sortClauses`, `start`, `rows`)
- Add `@Nullable` to `SearchResponse.maxScore` (nullable when scoring is disabled)
- Add `@NullMarked` `package-info.java` for the `search` subpackage so NullAway enforces null safety
- Fix test code to use null-safe dereference patterns (`assertNotNull` before `Map.get()` results)
- Correctly expresses the nullability contract under the existing `@NullMarked` package declaration

## Test plan
- [x] `./gradlew build` passes (including NullAway checks)
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)