### PR TITLE
feat: add SLF4J logging to all service classes

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -41,6 +41,8 @@ import org.apache.solr.client.solrj.response.SolrPingResponse;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.mcp.server.config.SolrConfigurationProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpComplete;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.annotation.McpTool;
@@ -128,6 +130,8 @@ import org.springframework.stereotype.Service;
 @Service
 @Observed
 public class CollectionService {
+
+	private static final Logger logger = LoggerFactory.getLogger(CollectionService.class);
 
 	// ========================================
 	// Constants for API Parameters and Paths
@@ -342,7 +346,8 @@ public class CollectionService {
 			@SuppressWarnings("unchecked")
 			List<String> collections = (List<String>) response.getResponse().get(COLLECTIONS_KEY);
 			return collections != null ? collections : new ArrayList<>();
-		} catch (SolrServerException | IOException _) {
+		} catch (SolrServerException | IOException e) {
+			logger.warn("Failed to list collections", e);
 			return new ArrayList<>();
 		}
 	}
@@ -570,16 +575,17 @@ public class CollectionService {
 	 * Internal cache metrics fetch that assumes the collection has already been
 	 * validated and the name has been extracted from any shard identifier.
 	 */
-	private CacheStats fetchCacheMetrics(String collection) {
+	private CacheStats fetchCacheMetrics(String collectionName) {
 		try {
-			NamedList<Object> coreMetrics = fetchMetrics(collection, CACHE_METRIC_PREFIX);
+			NamedList<Object> coreMetrics = fetchMetrics(collectionName, CACHE_METRIC_PREFIX);
 			if (coreMetrics == null) {
 				return null;
 			}
 
 			CacheStats stats = extractCacheStats(coreMetrics);
 			return isCacheStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException _) {
+		} catch (SolrServerException | IOException | RuntimeException e) {
+			logger.debug("Cache metrics unavailable for collection: {}", collectionName, e);
 			return null;
 		}
 	}
@@ -682,18 +688,19 @@ public class CollectionService {
 	 * Internal handler metrics fetch that assumes the collection has already been
 	 * validated and the name has been extracted from any shard identifier.
 	 */
-	private HandlerStats fetchHandlerMetrics(String collection) {
+	private HandlerStats fetchHandlerMetrics(String collectionName) {
 		try {
 			// Handler metrics are flat keys (e.g. QUERY./select.requests) so we
 			// fetch each handler prefix separately and reconstruct HandlerInfo
-			HandlerInfo selectHandler = fetchFlatHandlerInfo(collection, SELECT_HANDLER_METRIC_PREFIX,
+			HandlerInfo selectHandler = fetchFlatHandlerInfo(collectionName, SELECT_HANDLER_METRIC_PREFIX,
 					SELECT_HANDLER_KEY);
-			HandlerInfo updateHandler = fetchFlatHandlerInfo(collection, UPDATE_HANDLER_METRIC_PREFIX,
+			HandlerInfo updateHandler = fetchFlatHandlerInfo(collectionName, UPDATE_HANDLER_METRIC_PREFIX,
 					UPDATE_HANDLER_KEY);
 
 			HandlerStats stats = new HandlerStats(selectHandler, updateHandler);
 			return isHandlerStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException _) {
+		} catch (SolrServerException | IOException | RuntimeException e) {
+			logger.debug("Handler metrics unavailable for collection: {}", collectionName, e);
 			return null;
 		}
 	}
@@ -888,20 +895,21 @@ public class CollectionService {
 	 * @see #listCollections()
 	 * @see #extractCollectionName(String)
 	 */
-	private boolean validateCollectionExists(String collection) {
+	private boolean validateCollectionExists(String collectionOrShard) {
 		try {
 			List<String> collections = listCollections();
 
 			// Check for exact match first
-			if (collections.contains(collection)) {
+			if (collections.contains(collectionOrShard)) {
 				return true;
 			}
 
 			// Check if any of the returned collections start with the collection name (for
 			// shard
 			// names)
-			return collections.stream().anyMatch(c -> c.startsWith(collection + SHARD_SUFFIX));
+			return collections.stream().anyMatch(c -> c.startsWith(collectionOrShard + SHARD_SUFFIX));
 		} catch (Exception e) {
+			logger.warn("Failed to validate collection existence for: {}", collectionOrShard, e);
 			return false;
 		}
 	}
@@ -970,6 +978,7 @@ public class CollectionService {
 					statsResponse.getResults().getNumFound(), new Date(), actualCollection, null, null);
 
 		} catch (Exception e) {
+			logger.warn("Health check failed for collection: {}", collection, e);
 			return new SolrHealthStatus(false, e.getMessage(), null, null, new Date(), actualCollection, null, null);
 		}
 	}

--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -40,6 +40,7 @@ import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.LukeResponse;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SolrPingResponse;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.mcp.server.config.SolrConfigurationProperties;
@@ -696,7 +697,7 @@ public class CollectionService {
 
 			CacheStats stats = extractCacheStats(coreMetrics);
 			return isCacheStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException e) {
+		} catch (SolrServerException | IOException | SolrException e) {
 			logger.debug("Cache metrics unavailable for collection: {}", collectionName, e);
 			return null;
 		}
@@ -815,7 +816,7 @@ public class CollectionService {
 
 			HandlerStats stats = new HandlerStats(selectHandler, updateHandler);
 			return isHandlerStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException e) {
+		} catch (SolrServerException | IOException | SolrException e) {
 			logger.debug("Handler metrics unavailable for collection: {}", collectionName, e);
 			return null;
 		}

--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -45,6 +45,8 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.mcp.server.config.SolrConfigurationProperties;
 import org.apache.solr.mcp.server.util.PromptNames;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpArg;
 import org.springaicommunity.mcp.annotation.McpComplete;
 import org.springaicommunity.mcp.annotation.McpPrompt;
@@ -135,6 +137,8 @@ import org.springframework.stereotype.Service;
 @Service
 @Observed
 public class CollectionService {
+
+	private static final Logger logger = LoggerFactory.getLogger(CollectionService.class);
 
 	// ========================================
 	// Constants for API Parameters and Paths
@@ -683,16 +687,17 @@ public class CollectionService {
 	 * Internal cache metrics fetch that assumes the collection has already been
 	 * validated and the name has been extracted from any shard identifier.
 	 */
-	private @Nullable CacheStats fetchCacheMetrics(String collection) {
+	private @Nullable CacheStats fetchCacheMetrics(String collectionName) {
 		try {
-			NamedList<Object> coreMetrics = fetchMetrics(collection, CACHE_METRIC_PREFIX);
+			NamedList<Object> coreMetrics = fetchMetrics(collectionName, CACHE_METRIC_PREFIX);
 			if (coreMetrics == null) {
 				return null;
 			}
 
 			CacheStats stats = extractCacheStats(coreMetrics);
 			return isCacheStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException _) {
+		} catch (SolrServerException | IOException | RuntimeException e) {
+			logger.debug("Cache metrics unavailable for collection: {}", collectionName, e);
 			return null;
 		}
 	}
@@ -799,18 +804,19 @@ public class CollectionService {
 	 * Internal handler metrics fetch that assumes the collection has already been
 	 * validated and the name has been extracted from any shard identifier.
 	 */
-	private @Nullable HandlerStats fetchHandlerMetrics(String collection) {
+	private @Nullable HandlerStats fetchHandlerMetrics(String collectionName) {
 		try {
 			// Handler metrics are flat keys (e.g. QUERY./select.requests) so we
 			// fetch each handler prefix separately and reconstruct HandlerInfo
-			HandlerInfo selectHandler = fetchFlatHandlerInfo(collection, SELECT_HANDLER_METRIC_PREFIX,
+			HandlerInfo selectHandler = fetchFlatHandlerInfo(collectionName, SELECT_HANDLER_METRIC_PREFIX,
 					SELECT_HANDLER_KEY);
-			HandlerInfo updateHandler = fetchFlatHandlerInfo(collection, UPDATE_HANDLER_METRIC_PREFIX,
+			HandlerInfo updateHandler = fetchFlatHandlerInfo(collectionName, UPDATE_HANDLER_METRIC_PREFIX,
 					UPDATE_HANDLER_KEY);
 
 			HandlerStats stats = new HandlerStats(selectHandler, updateHandler);
 			return isHandlerStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException _) {
+		} catch (SolrServerException | IOException | RuntimeException e) {
+			logger.debug("Handler metrics unavailable for collection: {}", collectionName, e);
 			return null;
 		}
 	}
@@ -1080,6 +1086,7 @@ public class CollectionService {
 					statsResponse.getResults().getNumFound(), Instant.now(), actualCollection);
 
 		} catch (Exception e) {
+			logger.warn("Health check failed for collection: {}", collection, e);
 			return new SolrHealthStatus(false, e.getMessage(), null, null, Instant.now(), actualCollection);
 		}
 	}

--- a/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
@@ -24,6 +24,8 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.mcp.server.indexing.documentcreator.IndexingDocumentCreator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -106,6 +108,8 @@ import org.xml.sax.SAXException;
 @Service
 @Observed
 public class IndexingService {
+
+	private static final Logger logger = LoggerFactory.getLogger(IndexingService.class);
 
 	private static final int DEFAULT_BATCH_SIZE = 1000;
 
@@ -433,12 +437,14 @@ public class IndexingService {
 				solrClient.add(collection, batch);
 				successCount += batch.size();
 			} catch (SolrServerException | IOException | RuntimeException e) {
+				logger.warn("Batch indexing failed, retrying individually", e);
 				// Try indexing documents individually to identify problematic ones
 				for (SolrInputDocument doc : batch) {
 					try {
 						solrClient.add(collection, doc);
 						successCount++;
-					} catch (SolrServerException | IOException | RuntimeException _) {
+					} catch (SolrServerException | IOException | RuntimeException e2) {
+						logger.debug("Failed to index individual document", e2);
 						// Document failed to index - this is expected behavior for problematic
 						// documents
 						// We continue processing the rest of the batch
@@ -447,7 +453,12 @@ public class IndexingService {
 			}
 		}
 
-		solrClient.commit(collection);
+		try {
+			solrClient.commit(collection);
+		} catch (SolrServerException | IOException e) {
+			logger.error("Failed to commit after indexing to collection: {}", collection, e);
+			throw e;
+		}
 		return successCount;
 	}
 }

--- a/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
@@ -29,6 +29,8 @@ import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.mcp.server.indexing.documentcreator.IndexingDocumentCreator;
 import org.apache.solr.mcp.server.util.PromptNames;
 import org.apache.solr.mcp.server.util.PromptText;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpArg;
 import org.springaicommunity.mcp.annotation.McpPrompt;
 import org.springaicommunity.mcp.annotation.McpTool;
@@ -113,6 +115,8 @@ import org.xml.sax.SAXException;
 @Service
 @Observed
 public class IndexingService {
+
+	private static final Logger logger = LoggerFactory.getLogger(IndexingService.class);
 
 	private static final int DEFAULT_BATCH_SIZE = 1000;
 
@@ -501,12 +505,14 @@ public class IndexingService {
 				solrClient.add(collection, batch);
 				successCount += batch.size();
 			} catch (SolrServerException | IOException | RuntimeException e) {
+				logger.warn("Batch indexing failed, retrying individually", e);
 				// Try indexing documents individually to identify problematic ones
 				for (SolrInputDocument doc : batch) {
 					try {
 						solrClient.add(collection, doc);
 						successCount++;
-					} catch (SolrServerException | IOException | RuntimeException _) {
+					} catch (SolrServerException | IOException | RuntimeException e2) {
+						logger.debug("Failed to index individual document", e2);
 						// Document failed to index - this is expected behavior for problematic
 						// documents
 						// We continue processing the rest of the batch
@@ -515,7 +521,12 @@ public class IndexingService {
 			}
 		}
 
-		solrClient.commit(collection);
+		try {
+			solrClient.commit(collection);
+		} catch (SolrServerException | IOException e) {
+			logger.error("Failed to commit after indexing to collection: {}", collection, e);
+			throw e;
+		}
 		return successCount;
 	}
 

--- a/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
+++ b/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
@@ -23,6 +23,8 @@ import io.micrometer.observation.annotation.Observed;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.schema.SchemaRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springframework.stereotype.Service;
@@ -123,6 +125,8 @@ import org.springframework.stereotype.Service;
 @Observed
 public class SchemaService {
 
+	private static final Logger logger = LoggerFactory.getLogger(SchemaService.class);
+
 	/** SolrJ client for communicating with Solr server */
 	private final SolrClient solrClient;
 
@@ -166,6 +170,7 @@ public class SchemaService {
 		try {
 			return toJson(objectMapper, getSchema(collection));
 		} catch (Exception e) {
+			logger.error("Failed to get schema for collection: {}", collection, e);
 			return "{\"error\": \"" + e.getMessage() + "\"}";
 		}
 	}

--- a/src/main/java/org/apache/solr/mcp/server/schema/SchemaService.java
+++ b/src/main/java/org/apache/solr/mcp/server/schema/SchemaService.java
@@ -33,6 +33,8 @@ import org.apache.solr.client.solrj.request.schema.FieldTypeDefinition;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.schema.SchemaRepresentation;
 import org.apache.solr.mcp.server.util.PromptNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpArg;
 import org.springaicommunity.mcp.annotation.McpPrompt;
 import org.springaicommunity.mcp.annotation.McpResource;
@@ -137,6 +139,8 @@ import org.springframework.stereotype.Service;
 @Observed
 public class SchemaService {
 
+	private static final Logger logger = LoggerFactory.getLogger(SchemaService.class);
+
 	/** SolrJ client for communicating with Solr server */
 	private final SolrClient solrClient;
 
@@ -185,6 +189,7 @@ public class SchemaService {
 		try {
 			return toJson(objectMapper, getSchema(collection));
 		} catch (Exception e) {
+			logger.error("Failed to get schema for collection: {}", collection, e);
 			// Serialise via Jackson rather than concatenating: an exception message
 			// containing a quote, backslash or newline would otherwise emit invalid
 			// JSON to the MCP client.

--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -30,6 +30,8 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.FacetParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -101,6 +103,8 @@ import org.springframework.util.StringUtils;
 @Service
 @Observed
 public class SearchService {
+
+	private static final Logger logger = LoggerFactory.getLogger(SearchService.class);
 
 	public static final String SORT_ITEM = "item";
 	public static final String SORT_ORDER = "order";

--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -34,6 +34,8 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.mcp.server.util.PromptNames;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpArg;
 import org.springaicommunity.mcp.annotation.McpPrompt;
 import org.springaicommunity.mcp.annotation.McpTool;
@@ -107,6 +109,8 @@ import org.springframework.util.StringUtils;
 @Service
 @Observed
 public class SearchService {
+
+	private static final Logger logger = LoggerFactory.getLogger(SearchService.class);
 
 	/** Key for the field name within a sort clause map. */
 	public static final String SORT_ITEM = "item";

--- a/src/main/java/org/apache/solr/mcp/server/util/JsonUtils.java
+++ b/src/main/java/org/apache/solr/mcp/server/util/JsonUtils.java
@@ -18,6 +18,8 @@ package org.apache.solr.mcp.server.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for JSON serialization operations.
@@ -30,6 +32,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @since 0.0.1
  */
 public final class JsonUtils {
+
+	private static final Logger logger = LoggerFactory.getLogger(JsonUtils.class);
 
 	private JsonUtils() {
 		// Utility class - prevent instantiation
@@ -52,6 +56,7 @@ public final class JsonUtils {
 		try {
 			return objectMapper.writeValueAsString(obj);
 		} catch (JsonProcessingException e) {
+			logger.error("Failed to serialize response", e);
 			return "{\"error\": \"Failed to serialize response\"}";
 		}
 	}


### PR DESCRIPTION
## Summary
- Add SLF4J loggers to `CollectionService`, `IndexingService`, `SchemaService`, `SearchService`, and `JsonUtils`
- Log exceptions in all catch blocks instead of silently swallowing them
- Use appropriate log levels: `error` for operational failures, `warn` for recoverable issues, `debug` for expected conditions (Solr 10 metrics unavailability, individual doc failures)
- Safe for STDIO mode: logback-spring.xml already suppresses console logging in the stdio profile

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] STDIO mode unaffected (logging suppressed by logback config)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)