### PR TITLE
fix: narrow catch clauses in fetchCacheMetrics/fetchHandlerMetrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,9 +339,11 @@ The Solr Docker image used in tests is configurable via the `solr.test.image` sy
 ### Solr 10 Compatibility
 
 Solr 10.0.0 is fully supported with the JSON wire format. The `/admin/mbeans` endpoint was
-removed in Solr 10; `getCacheMetrics()` and `getHandlerMetrics()` now catch `RuntimeException`
-(which covers `RemoteSolrException`) so they degrade gracefully and return `null`. Tests that
-check `cacheStats` and `handlerStats` already handle `null` values.
+removed in Solr 10; `getCacheMetrics()` and `getHandlerMetrics()` catch `SolrException` (which
+`RemoteSolrException` extends) so they degrade gracefully and return `null`. Tests that check
+`cacheStats` and `handlerStats` already handle `null` values. The catch is deliberately *not*
+`RuntimeException`: an unrelated runtime failure inside metrics parsing should surface as a bug,
+not be silently reported as "metrics unavailable".
 
 Remaining known differences from Solr 9:
 - **`/admin/mbeans` removed:** Cache and handler stats from `getCollectionStats()` will always be `null` on Solr 10. A future migration to `/admin/metrics` will restore these metrics.

--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -38,6 +38,7 @@ import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.LukeResponse;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SolrPingResponse;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.mcp.server.config.SolrConfigurationProperties;
@@ -579,7 +580,7 @@ public class CollectionService {
 
 			CacheStats stats = extractCacheStats(coreMetrics);
 			return isCacheStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException _) {
+		} catch (SolrServerException | IOException | SolrException e) {
 			return null;
 		}
 	}
@@ -693,7 +694,7 @@ public class CollectionService {
 
 			HandlerStats stats = new HandlerStats(selectHandler, updateHandler);
 			return isHandlerStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException _) {
+		} catch (SolrServerException | IOException | SolrException e) {
 			return null;
 		}
 	}

--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -40,6 +40,7 @@ import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.LukeResponse;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SolrPingResponse;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.mcp.server.config.SolrConfigurationProperties;
@@ -692,7 +693,7 @@ public class CollectionService {
 
 			CacheStats stats = extractCacheStats(coreMetrics);
 			return isCacheStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException _) {
+		} catch (SolrServerException | IOException | SolrException _) {
 			return null;
 		}
 	}
@@ -810,7 +811,7 @@ public class CollectionService {
 
 			HandlerStats stats = new HandlerStats(selectHandler, updateHandler);
 			return isHandlerStatsEmpty(stats) ? null : stats;
-		} catch (SolrServerException | IOException | RuntimeException _) {
+		} catch (SolrServerException | IOException | SolrException _) {
 			return null;
 		}
 	}


### PR DESCRIPTION
## Summary
- Narrow catch from `RuntimeException` to `SolrException` in `fetchCacheMetrics()` and `fetchHandlerMetrics()`
- Still catches Solr 10 `RemoteSolrException` (subclass of `SolrException`) for graceful degradation when `/admin/mbeans` is unavailable
- Programming bugs (NPE, ClassCastException, etc.) now propagate instead of being silently swallowed

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)