### PR TITLE
fix: narrow validateCollectionExists catch clause

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -878,8 +878,9 @@ public class CollectionService {
 	 * <strong>Error Handling:</strong>
 	 *
 	 * <p>
-	 * Returns {@code false} if validation fails due to communication errors,
-	 * allowing calling methods to handle missing collections appropriately.
+	 * Communication errors are handled by {@link #listCollections()}, which returns
+	 * an empty list on failure. Any unexpected runtime exceptions propagate
+	 * naturally rather than being silently converted to {@code false}.
 	 *
 	 * @param collection
 	 *            the collection name to validate
@@ -889,21 +890,17 @@ public class CollectionService {
 	 * @see #extractCollectionName(String)
 	 */
 	private boolean validateCollectionExists(String collection) {
-		try {
-			List<String> collections = listCollections();
+		List<String> collections = listCollections();
 
-			// Check for exact match first
-			if (collections.contains(collection)) {
-				return true;
-			}
-
-			// Check if any of the returned collections start with the collection name (for
-			// shard
-			// names)
-			return collections.stream().anyMatch(c -> c.startsWith(collection + SHARD_SUFFIX));
-		} catch (Exception e) {
-			return false;
+		// Check for exact match first
+		if (collections.contains(collection)) {
+			return true;
 		}
+
+		// Check if any of the returned collections start with the collection name (for
+		// shard
+		// names)
+		return collections.stream().anyMatch(c -> c.startsWith(collection + SHARD_SUFFIX));
 	}
 
 	/**

--- a/src/test/java/org/apache/solr/mcp/server/collection/CollectionServiceTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/collection/CollectionServiceTest.java
@@ -403,8 +403,12 @@ class CollectionServiceTest {
 	// Cache metrics tests
 	@Test
 	void getCacheMetrics_WithNonExistentCollection_ShouldReturnNull() {
-		// When - Mock will not have collection configured
-		CacheStats result = collectionService.getCacheMetrics("nonexistent");
+		// Given - listCollections returns empty (collection not found)
+		CollectionService spyService = spy(collectionService);
+		doReturn(Collections.emptyList()).when(spyService).listCollections();
+
+		// When
+		CacheStats result = spyService.getCacheMetrics("nonexistent");
 
 		// Then
 		assertNull(result);
@@ -544,8 +548,12 @@ class CollectionServiceTest {
 	// Handler metrics tests
 	@Test
 	void getHandlerMetrics_WithNonExistentCollection_ShouldReturnNull() {
-		// When - Mock will not have collection configured
-		HandlerStats result = collectionService.getHandlerMetrics("nonexistent");
+		// Given - listCollections returns empty (collection not found)
+		CollectionService spyService = spy(collectionService);
+		doReturn(Collections.emptyList()).when(spyService).listCollections();
+
+		// When
+		HandlerStats result = spyService.getHandlerMetrics("nonexistent");
 
 		// Then
 		assertNull(result);


### PR DESCRIPTION
## Summary
- Remove overly broad `catch (Exception e)` from `validateCollectionExists()` that silently converted all errors (including NPE, ClassCastException) to "collection not found"
- `listCollections()` already catches `SolrServerException | IOException` internally, so the try-catch was unnecessary
- Unexpected RuntimeExceptions now propagate naturally instead of being swallowed
- Update tests that relied on the swallowed NPE to properly stub `listCollections()`

## Test plan
- [x] `./gradlew build` passes (all 228 tests, 0 failures)
- [x] `./gradlew nativeTest -Pnative` passes (119/119 tests)
- [x] No regressions — existing `validateCollectionExists` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)