### PR TITLE
fix(security): require authentication for metadata MCP tools

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -333,6 +333,7 @@ public class CollectionService {
 	 *         them
 	 * @see CollectionAdminRequest.List
 	 */
+	@PreAuthorize("isAuthenticated()")
 	@McpTool(name = "list-collections", description = "List solr collections")
 	public List<String> listCollections() {
 		try {
@@ -407,6 +408,7 @@ public class CollectionService {
 	 * @see LukeRequest
 	 * @see #extractCollectionName(String)
 	 */
+	@PreAuthorize("isAuthenticated()")
 	@McpTool(name = "get-collection-stats", description = "Get stats/metrics on a Solr collection")
 	public SolrMetrics getCollectionStats(
 			@McpToolParam(description = "Solr collection to get stats/metrics for") String collection)
@@ -955,6 +957,7 @@ public class CollectionService {
 	 * @see SolrHealthStatus
 	 * @see SolrPingResponse
 	 */
+	@PreAuthorize("isAuthenticated()")
 	@McpTool(name = "check-health", description = "Check health of a Solr collection")
 	public SolrHealthStatus checkHealth(@McpToolParam(description = "Solr collection") String collection) {
 		String actualCollection = extractCollectionName(collection);

--- a/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
+++ b/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
@@ -25,6 +25,7 @@ import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.schema.SchemaRepresentation;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 /**
@@ -249,6 +250,7 @@ public class SchemaService {
 	 * @see SchemaRequest
 	 * @see org.apache.solr.client.solrj.response.schema.SchemaResponse
 	 */
+	@PreAuthorize("isAuthenticated()")
 	@McpTool(name = "get-schema", description = "Get schema for a Solr collection")
 	public SchemaRepresentation getSchema(String collection) throws Exception {
 		SchemaRequest schemaRequest = new SchemaRequest();


### PR DESCRIPTION
## Summary
Adds `@PreAuthorize(\"isAuthenticated()\")` to four MCP tools that previously allowed anonymous access in HTTP mode (when security is enabled):

- `CollectionService.listCollections`
- `CollectionService.getCollectionStats`
- `CollectionService.checkHealth`
- `SchemaService.getSchema`

These expose collection inventory, document counts, cache/handler stats, health, and schema fields — useful reconnaissance for an attacker probing the underlying Solr cluster. They were reachable anonymously because the `SecurityFilterChain` permits `/mcp` at the HTTP layer (matching the upstream [`spring-ai-community/mcp-security` "secured tools" sample](https://github.com/spring-ai-community/mcp-security/blob/main/samples/sample-mcp-server-secured-tools/src/main/java/org/springaicommunity/mcp/security/sample/server/securedtools/McpServerConfiguration.java), which relies entirely on `@PreAuthorize` for per-tool gating). The other tool methods (`search`, `index-*`, `create-collection`) already had this annotation.

This is the canonical pattern from the upstream sample — the filter chain stays `permitAll` on `/mcp`, and method-level security gates each tool individually.

## Behavior
- **STDIO mode**: no change. `MethodSecurityConfiguration` is `@Profile(\"http\")`, so the annotation is inert.
- **HTTP mode with `http.security.enabled=false`**: no change. Method security bean isn't loaded.
- **HTTP mode with `http.security.enabled=true`**: previously-anonymous tools now require a valid OAuth2 bearer token. This is the intended security model.

## Test plan
- [x] `./gradlew spotlessApply` clean
- [x] `./gradlew build` passes (unit + integration tests)
- [ ] Manual verification with MCP Inspector: confirm tools return 401 when no token is sent and 200 with a valid token

🤖 Generated with [Claude Code](https://claude.com/claude-code)