### PR TITLE
fix(security): replace permissive CORS wildcard with explicit allowlist

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
+++ b/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
@@ -39,6 +39,9 @@ class HttpSecurityConfiguration {
 	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:}")
 	private String issuerUrl;
 
+	@Value("${mcp.cors.allowed-origins}")
+	private List<String> allowedOrigins;
+
 	@Bean
 	@ConditionalOnProperty(name = "http.security.enabled", havingValue = "true", matchIfMissing = true)
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -69,9 +72,19 @@ class HttpSecurityConfiguration {
 
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOriginPatterns(List.of("*"));
-		configuration.setAllowedMethods(List.of("*"));
-		configuration.setAllowedHeaders(List.of("*"));
+		// Use the strict setAllowedOrigins API (not setAllowedOriginPatterns) so the
+		// browser-spec rule that wildcards cannot be combined with credentials is
+		// enforced.
+		// Origins are configurable via the mcp.cors.allowed-origins property
+		// (env: MCP_CORS_ALLOWED_ORIGINS) and default to the MCP Inspector's local
+		// proxy.
+		configuration.setAllowedOrigins(allowedOrigins);
+		// Only the HTTP methods used by the MCP Streamable HTTP transport.
+		configuration.setAllowedMethods(List.of("GET", "POST", "DELETE", "OPTIONS"));
+		// Only the headers the MCP specification requires for the Streamable HTTP
+		// transport.
+		configuration.setAllowedHeaders(
+				List.of("Authorization", "Content-Type", "Mcp-Session-Id", "MCP-Protocol-Version", "Last-Event-ID"));
 		configuration.setAllowCredentials(true);
 
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/resources/application-http.properties
+++ b/src/main/resources/application-http.properties
@@ -13,6 +13,10 @@ spring.docker.compose.enabled=true
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${OAUTH2_ISSUER_URI:https://your-auth0-domain.auth0.com/}
 # Security toggle - set to true to enable OAuth2 authentication, false to bypass
 http.security.enabled=${HTTP_SECURITY_ENABLED:false}
+# Comma-separated list of allowed CORS origins for the MCP HTTP endpoint.
+# Defaults to MCP Inspector's local proxy. Add additional origins (browser-based
+# MCP clients, internal dashboards) as needed. Do NOT use "*" with credentials.
+mcp.cors.allowed-origins=${MCP_CORS_ALLOWED_ORIGINS:http://localhost:6274,http://127.0.0.1:6274}
 # observability
 management.endpoints.web.exposure.include=health,sbom,metrics,info,loggers,prometheus
 # Enable @Observed annotation support for custom spans


### PR DESCRIPTION
## Summary

The HTTP transport's CORS configuration used `setAllowedOriginPatterns(\"*\")` together with `allowCredentials=true`. This is Spring's escape hatch around the MDN/W3C CORS rule that wildcard origins cannot be combined with credentials, and it triggers [CWE-942](https://cwe.mitre.org/data/definitions/942.html) per the OWASP HTML5 Security Cheat Sheet.

This PR switches to the strict `setAllowedOrigins(...)` API backed by a configurable allowlist (`mcp.cors.allowed-origins` / `MCP_CORS_ALLOWED_ORIGINS`) that defaults to the MCP Inspector's local proxy ports (`http://localhost:6274,http://127.0.0.1:6274`).

Allowed methods are tightened to `GET, POST, DELETE, OPTIONS` and allowed headers to `Authorization, Content-Type, Mcp-Session-Id, MCP-Protocol-Version, Last-Event-ID` — the explicit set required by the MCP Streamable HTTP transport spec. Operators running the MCP server with browser-based clients or dashboards beyond the Inspector add origins via the env var. Bearer-token auth flows continue to work because `allowCredentials` is preserved.

## Test plan
- [x] \`./gradlew spotlessApply\` clean
- [x] \`./gradlew build\` passes (full test suite, 43s)
- [ ] Manual verification with MCP Inspector at http://localhost:6274 still completes a request flow

## References
- [MDN — CORS, Credentialed requests and wildcards](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#credentialed_requests_and_wildcards)
- [CWE-942: Permissive Cross-domain Policy with Untrusted Domains](https://cwe.mitre.org/data/definitions/942.html)
- [OWASP HTML5 Security Cheat Sheet (CORS)](https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#cross-origin-resource-sharing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)