### PR TITLE
fix(security): enable JWT audience validation and declare MCP resource path

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
+++ b/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
@@ -50,9 +50,20 @@ class HttpSecurityConfiguration {
 					auth.requestMatchers("/mcp").permitAll();
 					auth.anyRequest().authenticated();
 				})
-				// Configure OAuth2 on the MCP server
+				// Configure OAuth2 on the MCP server.
+				//
+				// resourcePath: declares "/mcp" as the canonical resource indicator
+				// for OAuth 2.0 Protected Resource Metadata (RFC 9728), which is what
+				// MCP clients use to discover the authorization server.
+				//
+				// validateAudienceClaim: per the MCP Authorization specification, MCP
+				// servers MUST validate that tokens were specifically issued for them.
+				// The audience is matched against the resource indicator (RFC 8707)
+				// configured above. The IdP must populate the JWT "aud" claim
+				// accordingly — see docs/security/http.md for IdP configuration notes.
 				.with(McpServerOAuth2Configurer.mcpServerOAuth2(),
-						mcpAuthorization -> mcpAuthorization.authorizationServer(issuerUrl))
+						mcpAuthorization -> mcpAuthorization.authorizationServer(issuerUrl).resourcePath("/mcp")
+								.validateAudienceClaim(true))
 				// MCP inspector
 				.cors(cors -> cors.configurationSource(corsConfigurationSource())).csrf(CsrfConfigurer::disable)
 				.build();

--- a/src/main/resources/application-http.properties
+++ b/src/main/resources/application-http.properties
@@ -10,6 +10,18 @@ spring.docker.compose.enabled=true
 # For Auth0: https://<your-auth0-domain>/.well-known/openid-configuration
 # For Keycloak: https://<keycloak-host>/realms/<realm-name>
 # For Okta: https://<your-okta-domain>/oauth2/default/.well-known/openid-configuration
+#
+# Audience validation: when http.security.enabled=true, the MCP server enforces
+# that incoming JWTs carry an "aud" claim matching its canonical resource URI
+# (per RFC 8707 / the MCP Authorization specification).  The IdP must be
+# configured to populate "aud" accordingly:
+#   * Auth0   - pass `audience=<MCP server URL>` on the auth request; Auth0
+#               reflects it into "aud" automatically.
+#   * Okta    - configure the audience on the Authorization Server.
+#   * Keycloak - add an "Audience" protocol mapper on a client scope and set
+#               `Included Custom Audience` to the MCP server URL (Keycloak does
+#               not yet honor RFC 8707 `resource=` natively, see
+#               docs/security/http.md).
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${OAUTH2_ISSUER_URI:https://your-auth0-domain.auth0.com/}
 # Security toggle - set to true to enable OAuth2 authentication, false to bypass
 http.security.enabled=${HTTP_SECURITY_ENABLED:false}


### PR DESCRIPTION
## Summary

Per the [MCP Authorization specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization):

> MCP servers MUST validate that tokens presented to them were specifically issued for their use … MUST reject tokens that do not include them in the audience claim.

Without audience validation, any valid JWT from the same IdP issued for any sibling application is accepted by this server — a classic token-confusion pivot ([CWE-345](https://cwe.mitre.org/data/definitions/345.html)).

This PR wires the existing \`McpServerOAuth2Configurer\` with:
- \`.resourcePath(\"/mcp\")\` — declares the canonical resource indicator surfaced via OAuth 2.0 Protected Resource Metadata ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728.html)).
- \`.validateAudienceClaim(true)\` — enforces that the JWT \`aud\` claim matches that resource indicator ([RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)).

These options are already provided by the upstream \`spring-ai-community/mcp-server-security\` library; this PR just turns them on.

## Operator impact

When \`http.security.enabled=true\`, the IdP must populate the JWT \`aud\` claim with the MCP server's URL. The expanded comment block in \`application-http.properties\` documents the per-IdP setup:

| IdP | Configuration |
|---|---|
| Auth0 | Client passes \`audience=<MCP URL>\` on auth request → reflected into \`aud\` automatically |
| Okta | Configure the audience on the Authorization Server |
| Keycloak | Add an **Audience** protocol mapper on a client scope (Keycloak [does not yet support RFC 8707 \`resource=\` natively](https://www.keycloak.org/securing-apps/mcp-authz-server)) |

\`http.security.enabled=false\` (current default) is unaffected.

## Test plan
- [x] \`./gradlew spotlessApply\` clean
- [x] \`./gradlew build\` passes (full test suite, 37s)
- [ ] Manual verification with an IdP issuing tokens carrying the correct \`aud\`

## Note on PR ordering
Touches \`HttpSecurityConfiguration.java\` and \`application-http.properties\`, which overlap with PR #121 (CORS allowlist). Whichever lands second will need a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)