### PR TITLE
fix(security): require authentication for actuator endpoints other than health

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
+++ b/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
@@ -45,14 +45,21 @@ class HttpSecurityConfiguration {
 	@Bean
 	@ConditionalOnProperty(name = "http.security.enabled", havingValue = "true", matchIfMissing = true)
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		return http
-				// ⬇️ Open every request on the server
-				.authorizeHttpRequests(auth -> {
-					auth.requestMatchers("/actuator").permitAll();
-					auth.requestMatchers("/actuator/*").permitAll();
-					auth.requestMatchers("/mcp").permitAll();
-					auth.anyRequest().authenticated();
-				})
+		return http.authorizeHttpRequests(auth -> {
+			// Liveness/readiness probes need anonymous access for load
+			// balancers and orchestrators. All other actuator endpoints
+			// (loggers, sbom, metrics, prometheus, info) require auth so
+			// that an unauthenticated caller cannot read the dependency
+			// tree, scrape metrics that map the tool surface, or — if
+			// path-matcher semantics ever shift — change log levels.
+			auth.requestMatchers("/actuator/health").permitAll();
+			auth.requestMatchers("/actuator", "/actuator/**").authenticated();
+			// /mcp is gated by @PreAuthorize on individual @McpTool
+			// methods, matching the spring-ai-community/mcp-security
+			// "secured tools" sample pattern.
+			auth.requestMatchers("/mcp").permitAll();
+			auth.anyRequest().authenticated();
+		})
 				// Configure OAuth2 on the MCP server.
 				//
 				// resourcePath: declares "/mcp" as the canonical resource indicator


### PR DESCRIPTION
## Summary

The secured filter chain matched \`/actuator\` and \`/actuator/*\` with \`permitAll\`, which exposed the entire actuator surface anonymously even when \`http.security.enabled=true\`:

- \`/actuator/sbom\` — full dependency tree (recon for known CVEs)
- \`/actuator/loggers\` — logger-name list (effectively a package-tree map of the codebase). The write endpoint at \`/actuator/loggers/{name}\` is currently shielded by Spring's path-matcher (the \`*\` wildcard doesn't span segments), but relying on that for security is brittle.
- \`/actuator/prometheus\` and \`/actuator/metrics\` — every \`@McpTool\` URI shows up as a metric label, plus JVM/Solr internals
- \`/actuator/info\` — build/git info

Tighten the matchers:
- \`/actuator/health\` stays anonymously reachable (load balancers and orchestrators need it)
- Everything else under \`/actuator\` requires an authenticated principal

Operators who need a metrics scraper without tokens can configure scraper auth or move actuator to a separate management port (\`management.server.port\` + \`management.server.address=127.0.0.1\`) — neither is changed here.

## Operator impact

| Endpoint | Before | After |
|---|---|---|
| \`/actuator/health\` | Anonymous ✓ | Anonymous ✓ |
| \`/actuator/sbom\` | Anonymous | Auth required |
| \`/actuator/loggers\` | Anonymous | Auth required |
| \`/actuator/prometheus\` | Anonymous | Auth required |
| \`/actuator/metrics\` | Anonymous | Auth required |
| \`/actuator/info\` | Anonymous | Auth required |

Only relevant when \`http.security.enabled=true\` (currently opt-in, defaults to false). The \`unsecured\` filter chain is unchanged.

## Test plan
- [x] \`./gradlew spotlessApply\` clean
- [x] \`./gradlew build\` passes (full test suite, 37s)

## Note on PR ordering
Touches \`HttpSecurityConfiguration.java\`. Overlaps with #121 (CORS allowlist) and #123 (audience validation). Whichever lands later will need a small rebase.

## References
- [CWE-732: Incorrect Permission Assignment for Critical Resource](https://cwe.mitre.org/data/definitions/732.html)
- [Spring Boot Actuator — Endpoints](https://docs.spring.io/spring-boot/reference/actuator/endpoints.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)