### PR TITLE
fix(security): make HTTP mode secure by default

### DIFF
--- a/src/main/resources/application-http.properties
+++ b/src/main/resources/application-http.properties
@@ -11,8 +11,11 @@ spring.docker.compose.enabled=true
 # For Keycloak: https://<keycloak-host>/realms/<realm-name>
 # For Okta: https://<your-okta-domain>/oauth2/default/.well-known/openid-configuration
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${OAUTH2_ISSUER_URI:https://your-auth0-domain.auth0.com/}
-# Security toggle - set to true to enable OAuth2 authentication, false to bypass
-http.security.enabled=${HTTP_SECURITY_ENABLED:false}
+# Security toggle - HTTP mode is secured by default. Set HTTP_SECURITY_ENABLED=false
+# to bypass OAuth2 authentication for local development only. Disabling security
+# in any environment reachable from the network is unsafe; the MCP Authorization
+# specification requires HTTP-based MCP servers to authenticate.
+http.security.enabled=${HTTP_SECURITY_ENABLED:true}
 # observability
 management.endpoints.web.exposure.include=health,sbom,metrics,info,loggers,prometheus
 # Enable @Observed annotation support for custom spans

--- a/src/test/java/org/apache/solr/mcp/server/observability/DistributedTracingTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/observability/DistributedTracingTest.java
@@ -54,6 +54,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest(properties = {
 		// Enable HTTP mode for observability
 		"spring.profiles.active=http",
+		// Tracing test does not exercise the OAuth2 filter chain; opt out of
+		// secure-by-default to avoid requiring a live JWKS endpoint at startup.
+		"http.security.enabled=false",
 		// Disable OTLP export in tests - we're using SimpleTracer instead
 		"management.otlp.tracing.endpoint=", "management.opentelemetry.logging.export.otlp.enabled=false",
 		// Ensure 100% sampling for tests


### PR DESCRIPTION
## Summary

Flip the \`http.security.enabled\` default from \`false\` to \`true\` so anyone running the MCP server in HTTP mode without explicit configuration gets the OAuth2-protected filter chain. The [MCP Authorization specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) requires HTTP-based MCP servers to authenticate; defaulting to insecure was a footgun for any operator exposing the server beyond their laptop.

Operators who explicitly want the unsecured filter chain (local development, integration tests) set \`HTTP_SECURITY_ENABLED=false\`.

## Operator impact

| Scenario | Before | After |
|---|---|---|
| \`PROFILES=http ./gradlew bootRun\` (no env) | Anonymous on every endpoint | OAuth2 enforced, requires \`OAUTH2_ISSUER_URI\` |
| \`HTTP_SECURITY_ENABLED=true PROFILES=http ./gradlew bootRun\` | OAuth2 enforced | OAuth2 enforced (no change) |
| \`HTTP_SECURITY_ENABLED=false PROFILES=http ./gradlew bootRun\` | Unsecured | Unsecured (explicit opt-out) |
| STDIO mode | No effect | No effect |

\`DistributedTracingTest\` activates the \`http\` profile but does not exercise the OAuth2 filter chain, so it opts out via \`http.security.enabled=false\` on \`@SpringBootTest\` properties — otherwise the test context would try to fetch JWKS from the placeholder issuer URI at startup and fail.

## Recommended pre-merge order

This PR is best landed **after** PRs that harden the secured filter chain itself:
- #120 — \`@PreAuthorize\` on metadata tools (so all MCP tools are gated, not just the four already annotated)
- #121 — CORS allowlist (so the secured server doesn't ship with wildcard origins)
- #123 — JWT audience validation (so accepted tokens are actually for this server)
- #124 — Actuator hardening (so the secured server doesn't expose loggers/sbom anonymously)

Otherwise this PR exposes any pre-existing weaknesses to anyone who flips the toggle by accident.

## Test plan
- [x] \`./gradlew spotlessApply\` clean
- [x] \`./gradlew build\` passes (full test suite, 36s, including \`DistributedTracingTest\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)