### PR TITLE
fix(security): validate filter queries, sort fields, and pagination bounds

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.SolrQuery;
@@ -104,6 +105,30 @@ public class SearchService {
 
 	public static final String SORT_ITEM = "item";
 	public static final String SORT_ORDER = "order";
+
+	/**
+	 * Maximum number of rows a single search may return. Requests above this are
+	 * clamped, not rejected, since SolrJ clients commonly oversize requests and
+	 * clamping is friendlier and equally effective at preventing OOM.
+	 */
+	private static final int MAX_ROWS = 1000;
+
+	/**
+	 * Maximum offset accepted for pagination. Beyond this, Solr's deep-paging is
+	 * itself a DoS surface (cursorMark should be used instead, but is not yet
+	 * exposed by this MCP tool).
+	 */
+	private static final int MAX_START = 100_000;
+
+	/**
+	 * Allowed pattern for sort field names. Restricted to letters, digits,
+	 * underscore, and dot (for nested fields). This rejects Solr-syntax
+	 * metacharacters such as {@code (}, {@code {}, {@code $}, and whitespace, all
+	 * of which can be used to switch the sort target into a function query and
+	 * build expensive query plans (e.g. {@code sort=if(rord(_val_:...),1,0) asc}).
+	 */
+	private static final Pattern SORT_FIELD_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_.]*$");
+
 	private final SolrClient solrClient;
 
 	/**
@@ -257,8 +282,24 @@ public class SearchService {
 		}
 
 		// filter queries
+		//
+		// Security: Solr's `fq` parameter is parsed by the same standard query
+		// parser as `q`, so it is vulnerable to the same {!xmlparser ...},
+		// {!join ...}, and {!frange ...} local-param injection vectors. Bind each
+		// user-supplied filter to a separate fq{n} request parameter and reference
+		// it from a constant {!edismax v=$fq{n}}. eDisMax does not honor a
+		// {!parser ...} prefix in its input, so injection attempts are treated as
+		// literal characters. See CWE-943.
 		if (!CollectionUtils.isEmpty(filterQueries)) {
-			solrQuery.setFilterQueries(filterQueries.toArray(new String[0]));
+			int i = 0;
+			for (String fq : filterQueries) {
+				if (StringUtils.hasText(fq)) {
+					String paramName = "fq" + i;
+					solrQuery.addFilterQuery("{!edismax v=$" + paramName + "}");
+					solrQuery.set(paramName, fq);
+					i++;
+				}
+			}
 		}
 
 		// facets
@@ -270,19 +311,42 @@ public class SearchService {
 		}
 
 		// sorting
+		//
+		// Security: Solr's `sort` parameter accepts function queries
+		// (e.g. sort=if(rord(_val_:...),1,0) asc), so a malicious sort field can
+		// build expensive query plans. Validate field names against a strict
+		// alphanumeric/underscore/dot pattern and reject anything else.
 		if (!CollectionUtils.isEmpty(sortClauses)) {
-			solrQuery.setSorts(sortClauses.stream()
-					.map(sortClause -> new SolrQuery.SortClause(sortClause.get(SORT_ITEM), sortClause.get(SORT_ORDER)))
-					.toList());
+			solrQuery.setSorts(sortClauses.stream().map(sortClause -> {
+				String field = sortClause.get(SORT_ITEM);
+				String order = sortClause.get(SORT_ORDER);
+				if (field == null || !SORT_FIELD_PATTERN.matcher(field).matches()) {
+					throw new IllegalArgumentException("Invalid sort field: " + field);
+				}
+				if (order == null) {
+					throw new IllegalArgumentException("Sort order must not be null");
+				}
+				SolrQuery.ORDER parsedOrder;
+				try {
+					parsedOrder = SolrQuery.ORDER.valueOf(order.toLowerCase());
+				} catch (IllegalArgumentException ex) {
+					throw new IllegalArgumentException("Invalid sort order: " + order, ex);
+				}
+				return new SolrQuery.SortClause(field, parsedOrder);
+			}).toList());
 		}
 
 		// pagination
+		//
+		// Security: clamp `start` and `rows` to bounded values to prevent OOM
+		// from unbounded row counts and to keep the caller out of Solr's
+		// deep-paging DoS surface. See CWE-1284.
 		if (start != null) {
-			solrQuery.setStart(start);
+			solrQuery.setStart(Math.min(Math.max(start, 0), MAX_START));
 		}
 
 		if (rows != null) {
-			solrQuery.setRows(rows);
+			solrQuery.setRows(Math.min(Math.max(rows, 0), MAX_ROWS));
 		}
 
 		final QueryResponse queryResponse = solrClient.query(collection, solrQuery);

--- a/src/test/java/org/apache/solr/mcp/server/search/SearchServiceTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/search/SearchServiceTest.java
@@ -92,7 +92,9 @@ class SearchServiceTest {
 		when(mockResponse.getFacetFields()).thenReturn(null);
 		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
 			SolrQuery q = invocation.getArgument(1);
-			assertArrayEquals(filterQueries.toArray(), q.getFilterQueries());
+			assertArrayEquals(new String[]{"{!edismax v=$fq0}", "{!edismax v=$fq1}"}, q.getFilterQueries());
+			assertEquals("genre_s:fantasy", q.get("fq0"));
+			assertEquals("price:[0 TO 10]", q.get("fq1"));
 			return mockResponse;
 		});
 		SearchService localService = new SearchService(mockClient);
@@ -166,7 +168,8 @@ class SearchServiceTest {
 		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
 			SolrQuery captured = invocation.getArgument(1);
 			assertEquals(query, captured.getQuery());
-			assertArrayEquals(filterQueries.toArray(), captured.getFilterQueries());
+			assertArrayEquals(new String[]{"{!edismax v=$fq0}"}, captured.getFilterQueries());
+			assertEquals("inStock:true", captured.get("fq0"));
 			assertNotNull(captured.getFacetFields());
 			assertEquals(start, captured.getStart());
 			assertEquals(rows, captured.getRows());
@@ -267,6 +270,256 @@ class SearchServiceTest {
 		assertEquals(2, result.documents().size());
 		assertNotNull(result.facets());
 		assertFalse(result.facets().isEmpty());
+	}
+
+	// --- Filter-query injection tests (CWE-943) -----------------------------
+
+	@Test
+	void search_WithPlainFilterQuery_ShouldBindToDereferencedParameter() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertArrayEquals(new String[]{"{!edismax v=$fq0}"}, q.getFilterQueries());
+			assertEquals("status:active", q.get("fq0"));
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, List.of("status:active"), null, null, null,
+				null);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithFilterQueryXmlParserInjection_ShouldBindIntoDereferencedParameter() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		String malicious = "{!xmlparser v='<root/>'}";
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertArrayEquals(new String[]{"{!edismax v=$fq0}"}, q.getFilterQueries());
+			assertEquals(malicious, q.get("fq0"));
+			// The malicious string must NOT appear as an actual fq value.
+			for (String fq : q.getFilterQueries()) {
+				assertNotEquals(malicious, fq);
+			}
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, List.of(malicious), null, null, null,
+				null);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithFilterQueryJoinInjection_ShouldBindIntoDereferencedParameter() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		String malicious = "{!join from=id fromIndex=other to=id}*:*";
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertArrayEquals(new String[]{"{!edismax v=$fq0}"}, q.getFilterQueries());
+			assertEquals(malicious, q.get("fq0"));
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, List.of(malicious), null, null, null,
+				null);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithFilterQueryFrangeInjection_ShouldBindIntoDereferencedParameter() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		String malicious = "{!frange l=0 u=100}price";
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertArrayEquals(new String[]{"{!edismax v=$fq0}"}, q.getFilterQueries());
+			assertEquals(malicious, q.get("fq0"));
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, List.of(malicious), null, null, null,
+				null);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithBlankFilterQuery_ShouldSkip() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertNull(q.getFilterQueries());
+			assertNull(q.get("fq0"));
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, List.of(" "), null, null, null, null);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithMultipleFilterQueries_ShouldBindEachToOwnParameter() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertArrayEquals(new String[]{"{!edismax v=$fq0}", "{!edismax v=$fq1}"}, q.getFilterQueries());
+			assertEquals("a:1", q.get("fq0"));
+			assertEquals("b:2", q.get("fq1"));
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, List.of("a:1", "b:2"), null, null, null,
+				null);
+		assertNotNull(result);
+	}
+
+	// --- Sort-clause validation tests ---------------------------------------
+
+	@Test
+	void search_WithValidSortField_ShouldApplySorting() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertEquals("title asc", q.get("sort"));
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, null, null,
+				List.of(Map.of("item", "title", "order", "asc")), null, null);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithDottedSortField_ShouldApplySorting() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertEquals("nested.field desc", q.get("sort"));
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, null, null,
+				List.of(Map.of("item", "nested.field", "order", "desc")), null, null);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithFunctionQuerySortInjection_ShouldThrow() {
+		SolrClient mockClient = mock(SolrClient.class);
+		SearchService localService = new SearchService(mockClient);
+		List<Map<String, String>> sortClauses = List.of(Map.of("item", "if(rord(x),1,0)", "order", "asc"));
+		assertThrows(IllegalArgumentException.class,
+				() -> localService.search("test_collection", null, null, null, sortClauses, null, null));
+	}
+
+	@Test
+	void search_WithBraceSortInjection_ShouldThrow() {
+		SolrClient mockClient = mock(SolrClient.class);
+		SearchService localService = new SearchService(mockClient);
+		List<Map<String, String>> sortClauses = List.of(Map.of("item", "{!func}foo", "order", "asc"));
+		assertThrows(IllegalArgumentException.class,
+				() -> localService.search("test_collection", null, null, null, sortClauses, null, null));
+	}
+
+	@Test
+	void search_WithValSortInjection_ShouldThrow() {
+		SolrClient mockClient = mock(SolrClient.class);
+		SearchService localService = new SearchService(mockClient);
+		List<Map<String, String>> sortClauses = List.of(Map.of("item", "_val_:expensive", "order", "asc"));
+		assertThrows(IllegalArgumentException.class,
+				() -> localService.search("test_collection", null, null, null, sortClauses, null, null));
+	}
+
+	@Test
+	void search_WithInvalidSortOrder_ShouldThrow() {
+		SolrClient mockClient = mock(SolrClient.class);
+		SearchService localService = new SearchService(mockClient);
+		List<Map<String, String>> sortClauses = List.of(Map.of("item", "title", "order", "hack"));
+		assertThrows(IllegalArgumentException.class,
+				() -> localService.search("test_collection", null, null, null, sortClauses, null, null));
+	}
+
+	// --- rows / start clamping tests (CWE-1284) -----------------------------
+
+	@Test
+	void search_WithExcessiveRows_ShouldClampToMax() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertEquals(Integer.valueOf(1000), q.getRows());
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, null, null, null, null, 2_000_000_000);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithNullRows_ShouldNotSetRowsParameter() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertNull(q.getRows());
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, null, null, null, null, null);
+		assertNotNull(result);
+	}
+
+	@Test
+	void search_WithExcessiveStart_ShouldClampToMax() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		QueryResponse mockResponse = mock(QueryResponse.class);
+		SolrDocumentList mockDocuments = createMockDocumentList();
+		when(mockResponse.getResults()).thenReturn(mockDocuments);
+		when(mockResponse.getFacetFields()).thenReturn(null);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenAnswer(invocation -> {
+			SolrQuery q = invocation.getArgument(1);
+			assertEquals(Integer.valueOf(100_000), q.getStart());
+			return mockResponse;
+		});
+		SearchService localService = new SearchService(mockClient);
+		SearchResponse result = localService.search("test_collection", null, null, null, null, 200_000, null);
+		assertNotNull(result);
 	}
 
 	private SolrDocumentList createMockDocumentList() {


### PR DESCRIPTION
## Summary

The [MCP Tools specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#security-considerations) requires servers to *"validate all tool inputs"*. The \`search\` tool previously passed three categories of caller input straight through to Solr without sanitization. This PR fixes all three.

### 1. Filter-query injection (\`fq\`)

\`filterQueries: List<String>\` was passed straight to \`solrQuery.addFilterQuery(...)\`. Solr's \`fq\` parameter uses the same standard query parser as \`q\`, so the \`{!xmlparser …}\`, \`{!join …}\`, and \`{!frange …}\` local-param injection vectors that #122 fixed for \`q\` are equally reachable via \`fq\`. Apply the same parameter-dereferencing pattern: bind each user-supplied filter to a separate \`fq{n}\` param and reference it from a constant \`{!edismax v=\$fq{n}}\`. ([CWE-943](https://cwe.mitre.org/data/definitions/943.html))

### 2. Sort-field injection

The \`item\` field of each \`sortClauses\` entry flowed into Solr's \`sort=\` parameter, which accepts function queries (\`sort=if(rord(_val_:…),1,0) asc\`) — enabling expensive query plans (lower-severity DoS). Validate field names against a strict \`^[a-zA-Z_][a-zA-Z0-9_.]*\$\` regex and reject anything else with \`IllegalArgumentException\`. The \`order\` value must parse as a valid \`SolrQuery.ORDER\` (\`asc\`/\`desc\`, case-insensitive).

### 3. Pagination bounds

\`rows\` and \`start\` were unbounded — a caller could request \`rows=2_000_000_000\` and OOM the JVM, or set \`start\` deep enough to trigger Solr's own deep-paging DoS surface. Clamp at \`MAX_ROWS=1000\` and \`MAX_START=100_000\` (both private static constants for easy adjustment), with a \`Math.max(value, 0)\` floor for negative inputs. ([CWE-1284](https://cwe.mitre.org/data/definitions/1284.html))

## Test plan
- [x] 6 new unit tests for \`fq\` (plain, xmlparser injection, join injection, frange injection, blank skipped, multiple filters)
- [x] 6 new unit tests for sort (valid plain, valid dotted, function-query injection, brace injection, \`_val_\` injection, invalid order)
- [x] 3 new unit tests for rows/start clamping (excessive rows clamped, null rows not set, excessive start clamped)
- [x] 2 existing tests updated to match the dereferenced form
- [x] \`./gradlew build\` passes (full suite, 37s)

## Note on PR ordering
Mirrors the parameter-dereferencing pattern from #122 (\`q\` injection). Both PRs touch \`SearchService.search\`; whichever merges later will need a trivial rebase.

## Out of scope
Rate limiting — the spec's other input-related \`MUST\`. Tracked separately so it can use a deliberate dependency choice (Bucket4j / resilience4j / Spring AOP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)