### PR TITLE
fix(solr): force HTTP/1.1 in SolrJ client to avoid flaky H2 EOF

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/config/SolrConfig.java
+++ b/src/main/java/org/apache/solr/mcp/server/config/SolrConfig.java
@@ -193,8 +193,10 @@ public class SolrConfig {
 		// JSON wire format for responses; XML wire format for update requests.
 		// The default JavaBin request writer uses a binary codec that requires
 		// additional reflection metadata in GraalVM native images.
+		// Force HTTP/1.1: the JDK HttpClient's HTTP/2 transport intermittently
+		// closes reused connections with an EOFException against Solr/Jetty.
 		return new HttpJdkSolrClient.Builder(url).withConnectionTimeout(CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-				.withIdleTimeout(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS).withResponseParser(jsonResponseParser)
-				.withRequestWriter(new XMLRequestWriter()).build();
+				.withIdleTimeout(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS).useHttp1_1(true)
+				.withResponseParser(jsonResponseParser).withRequestWriter(new XMLRequestWriter()).build();
 	}
 }


### PR DESCRIPTION
## Summary

The JDK 25 `HttpClient`'s HTTP/2 transport intermittently closes reused connections with `java.io.EOFException` against Solr/Jetty, causing test flakiness on CI runners. Recently observed in:

- `SearchServiceIntegrationTest.testSpecialCharactersInQuery` (older report)
- `SearchServiceIntegrationTest.testCombinedSortingAndFiltering` (today, native CI run)
- `IndexingServiceIntegrationTest.testIndexJsonDocumentsWithNestedObjects` (today, second attempt)

Each run picks a different victim test — the common thread is `Caused by: java.io.EOFException at Http2Connection.java:1903`.

HTTP/2 multiplexing is not needed for our usage (a single MCP server talking to Solr); force HTTP/1.1 on `HttpJdkSolrClient` via `useHttp1_1(true)` for deterministic behavior.

## Diff

One-line change: add `.useHttp1_1(true)` to the `HttpJdkSolrClient.Builder` chain in `SolrConfig.solrClient()`. Plus a comment explaining why.

```diff
-		return new HttpJdkSolrClient.Builder(url).withConnectionTimeout(CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-				.withIdleTimeout(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS).withResponseParser(jsonResponseParser)
-				.withRequestWriter(new XMLRequestWriter()).build();
+		return new HttpJdkSolrClient.Builder(url).withConnectionTimeout(CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+				.withIdleTimeout(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS).useHttp1_1(true)
+				.withResponseParser(jsonResponseParser).withRequestWriter(new XMLRequestWriter()).build();
```

## Background

This fix was authored locally as part of the `fix/solrj-force-http1` branch back in May 2026 but never landed upstream. It's been carried in derivative branches and rediscovered today when the same flake bit a different test in CI for ongoing native-image work.

## Test plan

- [ ] CI green (no transient `EOFException` from `Http2Connection.java`)
- [ ] No functional regression: SolrJ continues to talk to Solr via HTTP/1.1, which is fully supported by Solr/Jetty

🤖 Generated with [Claude Code](https://claude.com/claude-code)