### PR TITLE
refactor(dtos): drop noise fields from MCP tool response records

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -26,7 +26,6 @@ import io.micrometer.observation.annotation.Observed;
 import io.modelcontextprotocol.spec.McpSchema.CompleteRequest;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import org.apache.solr.client.solrj.SolrClient;
@@ -525,7 +524,7 @@ public class CollectionService {
 		QueryResponse statsResponse = solrClient.query(actualCollection, new SolrQuery(ALL_DOCUMENTS_QUERY).setRows(0));
 
 		return new SolrMetrics(buildIndexStats(lukeResponse), buildQueryStats(statsResponse),
-				fetchCacheMetrics(actualCollection), fetchHandlerMetrics(actualCollection), new Date());
+				fetchCacheMetrics(actualCollection), fetchHandlerMetrics(actualCollection));
 	}
 
 	/**
@@ -1069,10 +1068,10 @@ public class CollectionService {
 					new SolrQuery(ALL_DOCUMENTS_QUERY).setRows(0));
 
 			return new SolrHealthStatus(true, null, pingResponse.getElapsedTime(),
-					statsResponse.getResults().getNumFound(), new Date(), actualCollection, null, null);
+					statsResponse.getResults().getNumFound(), actualCollection);
 
 		} catch (Exception e) {
-			return new SolrHealthStatus(false, e.getMessage(), null, null, new Date(), actualCollection, null, null);
+			return new SolrHealthStatus(false, e.getMessage(), null, null, actualCollection);
 		}
 	}
 
@@ -1136,7 +1135,7 @@ public class CollectionService {
 		CollectionAdminRequest.createCollection(name, effectiveConfigSet, effectiveShards, effectiveRf)
 				.process(solrClient);
 
-		return new CollectionCreationResult(name, true, "Collection created successfully", new Date());
+		return new CollectionCreationResult(name);
 	}
 
 	/**

--- a/src/main/java/org/apache/solr/mcp/server/collection/Dtos.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/Dtos.java
@@ -16,10 +16,8 @@
  */
 package org.apache.solr.mcp.server.collection;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.util.Date;
 
 /**
  * Data Transfer Objects (DTOs) for the Apache Solr MCP Server.
@@ -101,10 +99,7 @@ record SolrMetrics(
 		 * Request handler performance metrics for select and update operations (may be
 		 * null)
 		 */
-		HandlerStats handlerStats,
-
-		/** Timestamp when these metrics were collected, formatted as ISO 8601 */
-		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") Date timestamp) {
+		HandlerStats handlerStats) {
 }
 
 /**
@@ -463,39 +458,21 @@ record SolrHealthStatus(
 		/** Total number of documents currently indexed in the collection */
 		Long totalDocuments,
 
-		/** Timestamp when this health check was performed, formatted as ISO 8601 */
-		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") Date lastChecked,
-
 		/** Name of the collection that was checked */
-		String collection,
-
-		/** Version of Solr server (when available) */
-		String solrVersion,
-
-		/** Additional status information or state description */
-		String status) {
+		String collection) {
 }
 
 /**
  * Result of a collection creation operation.
  *
  * <p>
- * Returned by the {@code create-collection} MCP tool to communicate the outcome
- * of a collection creation request. On success, {@code success} is {@code true}
- * and {@code createdAt} records when the operation completed.
+ * Returned by the {@code create-collection} MCP tool to echo the name of the
+ * newly-created collection. Failures throw rather than producing this result,
+ * so there is no need for a {@code success} flag.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 record CollectionCreationResult(
 		/** Name of the collection that was created */
-		String name,
-
-		/** Whether the collection was successfully created */
-		boolean success,
-
-		/** Optional message describing the outcome */
-		String message,
-
-		/** Timestamp when the collection was created, formatted as ISO 8601 */
-		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") Date createdAt) {
+		String name) {
 }

--- a/src/test/java/org/apache/solr/mcp/server/McpClientIntegrationTestBase.java
+++ b/src/test/java/org/apache/solr/mcp/server/McpClientIntegrationTestBase.java
@@ -163,7 +163,7 @@ public abstract class McpClientIntegrationTestBase {
 		assertNotNull(result);
 		assertNotError(result);
 		String text = extractText(result);
-		assertTrue(text.contains("success") || text.contains("true"), "Collection creation should succeed: " + text);
+		assertTrue(text.contains(COLLECTION), "Collection creation result should echo the collection name: " + text);
 	}
 
 	@Test
@@ -416,8 +416,8 @@ public abstract class McpClientIntegrationTestBase {
 		assertNotNull(result);
 		assertNotError(result);
 		String text = extractText(result);
-		assertTrue(text.contains("success") || text.contains("true"),
-				"Shows collection creation should succeed: " + text);
+		assertTrue(text.contains(SHOWS_COLLECTION),
+				"Shows collection creation result should echo the collection name: " + text);
 	}
 
 	@Test

--- a/src/test/java/org/apache/solr/mcp/server/collection/CollectionServiceIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/collection/CollectionServiceIntegrationTest.java
@@ -71,7 +71,7 @@ class CollectionServiceIntegrationTest {
 	void setupCollectionWithData() throws Exception {
 		// 1. Create collection via CollectionService MCP tool
 		CollectionCreationResult created = collectionService.createCollection(TEST_COLLECTION, null, null, null);
-		assertTrue(created.success(), "Collection creation should succeed: " + created.message());
+		assertEquals(TEST_COLLECTION, created.name(), "Collection creation should echo collection name");
 		log.debug("Test collection created: {}", TEST_COLLECTION);
 
 		// 2. Index documents via IndexingService MCP tool
@@ -120,7 +120,6 @@ class CollectionServiceIntegrationTest {
 		SolrMetrics metrics = collectionService.getCollectionStats(TEST_COLLECTION);
 
 		assertNotNull(metrics);
-		assertNotNull(metrics.timestamp());
 
 		// Index stats should reflect the documents we indexed
 		IndexStats indexStats = metrics.indexStats();
@@ -171,9 +170,6 @@ class CollectionServiceIntegrationTest {
 		assertTrue(status.responseTime() >= 0);
 
 		assertEquals((long) DOC_COUNT, status.totalDocuments(), "Health check should report indexed document count");
-
-		assertNotNull(status.lastChecked());
-		assertTrue(System.currentTimeMillis() - status.lastChecked().getTime() < 5000);
 	}
 
 	@Test
@@ -258,9 +254,7 @@ class CollectionServiceIntegrationTest {
 
 		CollectionCreationResult result = collectionService.createCollection(name, null, null, null);
 
-		assertTrue(result.success());
 		assertEquals(name, result.name());
-		assertNotNull(result.createdAt());
 
 		List<String> collections = collectionService.listCollections();
 		boolean exists = collections.contains(name)

--- a/src/test/java/org/apache/solr/mcp/server/collection/CollectionServiceTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/collection/CollectionServiceTest.java
@@ -836,9 +836,7 @@ class CollectionServiceTest {
 		CollectionCreationResult result = collectionService.createCollection("new_collection", "_default", 1, 1);
 
 		assertNotNull(result);
-		assertTrue(result.success());
 		assertEquals("new_collection", result.name());
-		assertNotNull(result.createdAt());
 	}
 
 	@Test
@@ -847,7 +845,6 @@ class CollectionServiceTest {
 
 		CollectionCreationResult result = collectionService.createCollection("defaults_collection", null, null, null);
 
-		assertTrue(result.success());
 		assertEquals("defaults_collection", result.name());
 	}
 

--- a/src/test/java/org/apache/solr/mcp/server/collection/ConferenceEndToEndIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/collection/ConferenceEndToEndIntegrationTest.java
@@ -66,7 +66,7 @@ class ConferenceEndToEndIntegrationTest {
 	@BeforeAll
 	void createAndIndexConferences() throws Exception {
 		CollectionCreationResult result = collectionService.createCollection(COLLECTION, null, null, null);
-		assertTrue(result.success(), "Collection creation should succeed: " + result.message());
+		assertEquals(COLLECTION, result.name(), "Collection creation should echo collection name");
 
 		String json = Files.readString(Path.of("mydata/devnexus-2026.json"));
 		indexingService.indexJsonDocuments(COLLECTION, json);


### PR DESCRIPTION
## Summary

Three MCP tool response records in \`Dtos.java\` carried fields that conveyed no real information to the LLM client. Removing them simplifies the JSON wire format and eliminates legacy \`java.util.Date\` usage entirely.

## Fields removed

| Record | Field | Why noise |
|---|---|---|
| \`SolrMetrics\` | \`timestamp\` (Date) | Always \"now\" — metrics collected synchronously per call. MCP host records call timing already. |
| \`SolrHealthStatus\` | \`lastChecked\` (Date) | Same: always \"now\". |
| \`SolrHealthStatus\` | \`solrVersion\` (String) | Always null in every code path. \`@JsonInclude(NON_NULL)\` was hiding it on the wire anyway. |
| \`SolrHealthStatus\` | \`status\` (String) | Same: always null. |
| \`CollectionCreationResult\` | \`success\` (boolean) | Always \`true\` on return — failures throw before reaching the result. |
| \`CollectionCreationResult\` | \`message\` (String) | Always the literal \"Collection created successfully\". |
| \`CollectionCreationResult\` | \`createdAt\` (Date) | Always \"now\". |

After this change:
- \`SolrMetrics\` → \`(indexStats, queryStats, cacheStats, handlerStats)\`
- \`SolrHealthStatus\` → \`(isHealthy, errorMessage, responseTime, totalDocuments, collection)\`
- \`CollectionCreationResult\` → \`(name)\`

## Date → Instant migration: not needed

The original motivation was \"why are we using \`java.util.Date\` instead of \`java.time.Instant\`?\" — once every \`Date\` field turned out to be cargo-culted noise rather than load-bearing state, the migration is moot. Both \`java.util.Date\` and \`com.fasterxml.jackson.annotation.JsonFormat\` imports drop from \`Dtos.java\` entirely.

## Wire format impact

For LLM clients consuming the existing JSON, the change is purely subtractive — three keys disappear from each affected response. Any code that depended on those values (none in this repo) would break, but since \`@JsonInclude(NON_NULL)\` was already dropping \`solrVersion\` and \`status\` from the wire, only \`timestamp\` / \`lastChecked\` / \`success\` / \`message\` / \`createdAt\` are visible behavioral changes.

## Test plan

- [x] \`./gradlew clean build\` — BUILD SUCCESSFUL, all tests pass
- [x] \`./gradlew nativeTest -Pnative\` — 157/157 tests pass, 0 failures
- [x] Test assertions updated where they referenced removed fields (\`CollectionServiceIntegrationTest\`, \`CollectionServiceTest\`, \`ConferenceEndToEndIntegrationTest\`, \`McpClientIntegrationTestBase\`)
- [ ] CI native + docker matrix on the PR

## Related

This addresses a sub-thread of review on #131 (schema modification PR), where the new \`SchemaUpdateResult\` followed the same convention and the reviewer asked why we used \`Date\`. After this PR merges, #131 will pick up the same treatment for \`SchemaUpdateResult\` via rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)