### PR TITLE
feat(mcp): annotate tools with behavior hints (readOnly/destructive/idempotent)

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -331,7 +331,7 @@ public class CollectionService {
 	 * @see CollectionAdminRequest.List
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "list-collections", description = "List solr collections")
+	@McpTool(name = "list-collections", annotations = @McpTool.McpAnnotations(readOnlyHint = true), description = "List solr collections")
 	public List<String> listCollections() throws SolrServerException, IOException {
 		CollectionAdminRequest.List request = new CollectionAdminRequest.List();
 		CollectionAdminResponse response = request.process(solrClient);
@@ -402,7 +402,7 @@ public class CollectionService {
 	 * @see #extractCollectionName(String)
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "get-collection-stats", description = "Get stats/metrics on a Solr collection")
+	@McpTool(name = "get-collection-stats", annotations = @McpTool.McpAnnotations(readOnlyHint = true), description = "Get stats/metrics on a Solr collection")
 	public SolrMetrics getCollectionStats(
 			@McpToolParam(description = "Solr collection to get stats/metrics for") String collection)
 			throws SolrServerException, IOException {
@@ -944,7 +944,7 @@ public class CollectionService {
 	 * @see SolrPingResponse
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "check-health", description = "Check health of a Solr collection")
+	@McpTool(name = "check-health", annotations = @McpTool.McpAnnotations(readOnlyHint = true), description = "Check health of a Solr collection")
 	public SolrHealthStatus checkHealth(@McpToolParam(description = "Solr collection") String collection) {
 		String actualCollection = extractCollectionName(collection);
 		try {
@@ -996,7 +996,7 @@ public class CollectionService {
 	 *             if there are I/O errors during communication
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "create-collection", description = "Create a new Solr collection. "
+	@McpTool(name = "create-collection", annotations = @McpTool.McpAnnotations(destructiveHint = false), description = "Create a new Solr collection. "
 			+ "configSet defaults to _default, numShards and replicationFactor default to 1.")
 	public CollectionCreationResult createCollection(
 			@McpToolParam(description = "Name of the collection to create") String name,

--- a/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/IndexingService.java
@@ -192,7 +192,7 @@ public class IndexingService {
 	 * @see #indexDocuments(String, List)
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "index-json-documents", description = "Index documents from json String into Solr collection")
+	@McpTool(name = "index-json-documents", annotations = @McpTool.McpAnnotations(idempotentHint = true), description = "Index documents from json String into Solr collection")
 	public String indexJsonDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "JSON string containing documents to index") String json)
 			throws IOException, SolrServerException {
@@ -260,7 +260,7 @@ public class IndexingService {
 	 * @see #indexDocuments(String, List)
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "index-csv-documents", description = "Index documents from CSV string into Solr collection")
+	@McpTool(name = "index-csv-documents", annotations = @McpTool.McpAnnotations(idempotentHint = true), description = "Index documents from CSV string into Solr collection")
 	public String indexCsvDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "CSV string containing documents to index") String csv)
 			throws IOException, SolrServerException {
@@ -352,7 +352,7 @@ public class IndexingService {
 	 * @see #indexDocuments(String, List)
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "index-xml-documents", description = "Index documents from XML string into Solr collection")
+	@McpTool(name = "index-xml-documents", annotations = @McpTool.McpAnnotations(idempotentHint = true), description = "Index documents from XML string into Solr collection")
 	public String indexXmlDocuments(@McpToolParam(description = "Solr collection to index into") String collection,
 			@McpToolParam(description = "XML string containing documents to index") String xml)
 			throws ParserConfigurationException, SAXException, IOException, SolrServerException {

--- a/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
+++ b/src/main/java/org/apache/solr/mcp/server/metadata/SchemaService.java
@@ -251,7 +251,7 @@ public class SchemaService {
 	 * @see org.apache.solr.client.solrj.response.schema.SchemaResponse
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "get-schema", description = "Get schema for a Solr collection")
+	@McpTool(name = "get-schema", annotations = @McpTool.McpAnnotations(readOnlyHint = true), description = "Get schema for a Solr collection")
 	public SchemaRepresentation getSchema(String collection) throws Exception {
 		SchemaRequest schemaRequest = new SchemaRequest();
 		return schemaRequest.process(solrClient, collection).getSchemaRepresentation();

--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -215,7 +215,7 @@ public class SearchService {
 	 *             If there's an I/O error
 	 */
 	@PreAuthorize("isAuthenticated()")
-	@McpTool(name = "search", description = """
+	@McpTool(name = "search", annotations = @McpTool.McpAnnotations(readOnlyHint = true), description = """
 			Search specified Solr collection with query, optional filters, facets, sorting, and pagination.
 			Note that solr has dynamic fields where name of field in schema may end with suffixes
 			_s: Represents a string field, used for exact string matching.

--- a/src/test/java/org/apache/solr/mcp/server/McpClientIntegrationTestBase.java
+++ b/src/test/java/org/apache/solr/mcp/server/McpClientIntegrationTestBase.java
@@ -24,8 +24,11 @@ import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -86,6 +89,47 @@ public abstract class McpClientIntegrationTestBase {
 		assertTrue(toolNames.contains("check-health"), "Should have check-health tool");
 		assertTrue(toolNames.contains("get-collection-stats"), "Should have get-collection-stats tool");
 		assertTrue(toolNames.contains("get-schema"), "Should have get-schema tool");
+	}
+
+	@Test
+	@Order(2)
+	void toolsExposeBehaviorHints() {
+		Map<String, Tool> tools = mcpClient.listTools().tools().stream()
+				.collect(Collectors.toMap(Tool::name, Function.identity()));
+
+		// Read-only tools — clients can call without approval prompts.
+		assertReadOnly(tools, "search");
+		assertReadOnly(tools, "list-collections");
+		assertReadOnly(tools, "get-collection-stats");
+		assertReadOnly(tools, "check-health");
+		assertReadOnly(tools, "get-schema");
+
+		// create-collection: additive write (provisions a new collection, not
+		// idempotent because a second call with the same name errors).
+		assertHint(tools, "create-collection", /* readOnly */ false, /* destructive */ false, /* idempotent */ false);
+
+		// Indexing: destructive (Solr overwrites by uniqueKey) but idempotent —
+		// posting the same JSON/CSV/XML twice leaves the index in the same state.
+		assertHint(tools, "index-json-documents", false, true, true);
+		assertHint(tools, "index-csv-documents", false, true, true);
+		assertHint(tools, "index-xml-documents", false, true, true);
+	}
+
+	private static void assertReadOnly(Map<String, Tool> tools, String name) {
+		Tool tool = tools.get(name);
+		assertNotNull(tool, name + " tool should be present");
+		assertNotNull(tool.annotations(), name + " should expose hints");
+		assertEquals(Boolean.TRUE, tool.annotations().readOnlyHint(), name + " should be readOnly");
+	}
+
+	private static void assertHint(Map<String, Tool> tools, String name, boolean readOnly, boolean destructive,
+			boolean idempotent) {
+		Tool tool = tools.get(name);
+		assertNotNull(tool, name + " tool should be present");
+		assertNotNull(tool.annotations(), name + " should expose hints");
+		assertEquals(readOnly, tool.annotations().readOnlyHint(), name + " readOnlyHint mismatch");
+		assertEquals(destructive, tool.annotations().destructiveHint(), name + " destructiveHint mismatch");
+		assertEquals(idempotent, tool.annotations().idempotentHint(), name + " idempotentHint mismatch");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Adds `@McpTool.McpAnnotations` to every MCP tool so clients can make sensible approval decisions instead of treating every call as worst-case destructive.

| Tool | readOnlyHint | destructiveHint | idempotentHint |
|---|---|---|---|
| `search`, `list-collections`, `get-collection-stats`, `check-health`, `get-schema` | `true` | n/a | n/a |
| `create-collection` | `false` (default) | `false` (additive provisioning) | `false` (default — re-creating errors) |
| `index-json-documents`, `index-csv-documents`, `index-xml-documents` | `false` (default) | `true` (default — Solr overwrites by uniqueKey) | `true` (re-posting same payload → same end state) |

## Why

NSA's *Model Context Protocol: Security Design Considerations* CSI (U/OO/6030316-26, May 2026) flags "poor approval workflows" as one of the top risks for MCP deployments. The CSI calls out that clients today often can't distinguish a read from a destructive write without parsing prose tool descriptions, which produces consent fatigue and pushes operators toward blanket approvals.

Exposing the spec's standard behavior hints is the server-side enabler clients need to build approval UX that doesn't desensitize users.

## Test plan

- [x] Extended `McpClientIntegrationTestBase.toolsExposeBehaviorHints` to assert hint values flow through `listTools` for every tool — runs under both HTTP and stdio transports, so the wire-level annotations are verified end-to-end.
- [x] `./gradlew build` passes locally (38s, all tests green).
- [x] Spotless check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)