### PR TITLE
feat(deps): upgrade Spring Boot to 3.5.14 and Spring AI to 1.1.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables 
 
 - **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
 - **Java:** 25+ (centralized in build.gradle.kts)
-- **Framework:** Spring Boot 3.5.13, Spring AI 1.1.4
+- **Framework:** Spring Boot 3.5.14, Spring AI 1.1.7
 - **License:** Apache 2.0
 
 ## Common Commands

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Build plugins
-spring-boot = "3.5.13"
+spring-boot = "3.5.14"
 spring-dependency-management = "1.1.7"
 errorprone-plugin = "5.1.0"
 jib = "3.5.3"
@@ -8,7 +8,7 @@ spotless = "7.0.2"
 graalvm-native = "0.10.6"
 
 # Main dependencies
-spring-ai = "1.1.4"
+spring-ai = "1.1.7"
 solr = "10.0.0"
 commons-csv = "1.14.1"
 jspecify = "1.0.0"


### PR DESCRIPTION
## Summary

- Bumps `spring-boot` from `3.5.13` to `3.5.14` in `gradle/libs.versions.toml`.
- Bumps `spring-ai` from `1.1.4` to `1.1.7` in `gradle/libs.versions.toml`.
- Updates the framework version reference in `AGENTS.md`.

No source changes are required for either bump.

## Test plan

- [x] `./gradlew spotlessApply build` — passes locally
- [ ] CI verifies JVM build, Docker integration tests, and native image build

🤖 Generated with [Claude Code](https://claude.com/claude-code)