### PR TITLE
chore(release): cut 1.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to AI coding assistants when working with code in th
 
 Solr MCP Server is a Spring AI Model Context Protocol (MCP) server that enables AI assistants to interact with Apache Solr. It provides tools for searching, indexing, and managing Solr collections through the MCP protocol.
 
-- **Status:** Apache incubating project (v0.0.2-SNAPSHOT)
+- **Status:** Apache incubating project (v1.0.0)
 - **Java:** 25+ (centralized in build.gradle.kts)
 - **Framework:** Spring Boot 3.5.14, Spring AI 1.1.7
 - **License:** Apache 2.0

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This starts Solr in SolrCloud mode with two sample collections: **films** (1,100
 ./gradlew build
 ```
 
-This produces `build/libs/solr-mcp-1.0.0-SNAPSHOT.jar`.
+This produces `build/libs/solr-mcp-1.0.0.jar`.
 
 #### 3. Connect your AI client
 
@@ -51,7 +51,7 @@ Add the server to your MCP client. For **Claude Desktop**, edit
   "mcpServers": {
     "solr-mcp": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/solr-mcp/build/libs/solr-mcp-1.0.0-SNAPSHOT.jar"],
+      "args": ["-jar", "/absolute/path/to/solr-mcp/build/libs/solr-mcp-1.0.0.jar"],
       "env": { "SOLR_URL": "http://localhost:8983/solr/" }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ val nativeImageBuildArgs =
     )
 
 group = "org.apache.solr"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.0"
 
 java {
     toolchain {

--- a/dev-docs/DEPLOYMENT.md
+++ b/dev-docs/DEPLOYMENT.md
@@ -14,7 +14,7 @@ Build directly to your local Docker daemon (requires Docker installed):
 ./gradlew jibDockerBuild
 ```
 
-This creates: `solr-mcp:1.0.0-SNAPSHOT`
+This creates: `solr-mcp:1.0.0`
 
 Verify:
 ```bash
@@ -30,7 +30,7 @@ Authenticate and push (no local Docker daemon required):
 docker login
 
 # Build and push
-./gradlew jib -Djib.to.image=YOUR_DOCKERHUB_USERNAME/solr-mcp:1.0.0-SNAPSHOT
+./gradlew jib -Djib.to.image=YOUR_DOCKERHUB_USERNAME/solr-mcp:1.0.0
 ```
 
 ### Push to GitHub Container Registry
@@ -46,7 +46,7 @@ export GITHUB_TOKEN=YOUR_GITHUB_TOKEN
 echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
 
 # Build and push
-./gradlew jib -Djib.to.image=ghcr.io/YOUR_GITHUB_USERNAME/solr-mcp:1.0.0-SNAPSHOT
+./gradlew jib -Djib.to.image=ghcr.io/YOUR_GITHUB_USERNAME/solr-mcp:1.0.0
 ```
 
 ### Multi-Platform Support
@@ -138,14 +138,14 @@ for the native image design and known risks.
 ### STDIO Mode (Default)
 
 ```bash
-docker run -i --rm solr-mcp:1.0.0-SNAPSHOT
+docker run -i --rm solr-mcp:1.0.0
 ```
 
 With custom Solr URL:
 ```bash
 docker run -i --rm \
   -e SOLR_URL=http://your-solr-host:8983/solr/ \
-  solr-mcp:1.0.0-SNAPSHOT
+  solr-mcp:1.0.0
 ```
 
 ### HTTP Mode
@@ -154,7 +154,7 @@ docker run -i --rm \
 docker run -p 8080:8080 --rm \
   -e PROFILES=http \
   -e SOLR_URL=http://your-solr-host:8983/solr/ \
-  solr-mcp:1.0.0-SNAPSHOT
+  solr-mcp:1.0.0
 ```
 
 ### Linux Host Networking
@@ -165,7 +165,7 @@ On Linux, to connect to Solr on the host machine:
 docker run -i --rm \
   --add-host=host.docker.internal:host-gateway \
   -e SOLR_URL=http://host.docker.internal:8983/solr/ \
-  solr-mcp:1.0.0-SNAPSHOT
+  solr-mcp:1.0.0
 ```
 
 ## GitHub Actions CI/CD
@@ -183,13 +183,13 @@ To publish images, use Jib from your local machine or set up your own workflow:
 - Docker Hub:
   ```bash
   docker login
-  ./gradlew jib -Djib.to.image=DOCKERHUB_USERNAME/solr-mcp:1.0.0-SNAPSHOT
+  ./gradlew jib -Djib.to.image=DOCKERHUB_USERNAME/solr-mcp:1.0.0
   ```
 - GitHub Container Registry (GHCR):
   ```bash
   export GITHUB_TOKEN=YOUR_GITHUB_TOKEN
   echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
-  ./gradlew jib -Djib.to.image=ghcr.io/YOUR_GITHUB_USERNAME/solr-mcp:1.0.0-SNAPSHOT
+  ./gradlew jib -Djib.to.image=ghcr.io/YOUR_GITHUB_USERNAME/solr-mcp:1.0.0
   ```
 
 ### MCP Registry Publishing
@@ -238,7 +238,7 @@ The `server.json` file defines MCP registry metadata:
     {
       "registryType": "docker",
       "identifier": "ghcr.io/apache/solr-mcp",
-      "version": "1.0.0-SNAPSHOT",
+      "version": "1.0.0",
       "transport": {
         "type": "stdio"
       }

--- a/dev-docs/DEVELOPMENT.md
+++ b/dev-docs/DEVELOPMENT.md
@@ -35,7 +35,7 @@ This project uses Gradle with version catalogs for dependency management. All de
 
 The build produces an executable JAR in `build/libs/`:
 
-- `solr-mcp-1.0.0-SNAPSHOT.jar` — Spring Boot executable (fat) JAR
+- `solr-mcp-1.0.0.jar` — Spring Boot executable (fat) JAR
 
 ### Publishing to Maven Local
 
@@ -116,7 +116,7 @@ This starts a Solr instance in SolrCloud mode with ZooKeeper and creates two sam
 
 Or using the JAR:
 ```bash
-java -jar build/libs/solr-mcp-1.0.0-SNAPSHOT.jar
+java -jar build/libs/solr-mcp-1.0.0.jar
 ```
 
 #### HTTP Mode
@@ -286,7 +286,7 @@ The project generates build metadata at build time via the Spring Boot Gradle pl
 - `build.artifact`: Artifact name (e.g., "solr-mcp")
 - `build.group`: Group ID (e.g., "org.apache.solr")
 - `build.name`: Project name
-- `build.version`: Version (e.g., "1.0.0-SNAPSHOT")
+- `build.version`: Version (e.g., "1.0.0")
 - `build.time`: Build timestamp
 
 This metadata is used by:
@@ -306,7 +306,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for detailed Docker build instructions.
 ./gradlew jibDockerBuild
 
 # Run the image
-docker run -i --rm solr-mcp:1.0.0-SNAPSHOT
+docker run -i --rm solr-mcp:1.0.0
 ```
 
 ### Docker Executable Configuration
@@ -482,7 +482,7 @@ Use Java Flight Recorder:
 
 ```bash
 java -XX:StartFlightRecording=duration=60s,filename=recording.jfr \
-     -jar build/libs/solr-mcp-1.0.0-SNAPSHOT.jar
+     -jar build/libs/solr-mcp-1.0.0.jar
 ```
 
 Analyze with Java Mission Control.

--- a/dev-docs/TROUBLESHOOTING.md
+++ b/dev-docs/TROUBLESHOOTING.md
@@ -37,7 +37,7 @@ Common issues and solutions when working with the Solr MCP Server.
    ```bash
    docker run -i --rm \
      --add-host=host.docker.internal:host-gateway \
-     solr-mcp:1.0.0-SNAPSHOT
+     solr-mcp:1.0.0
    ```
 
 ### Collection not found
@@ -143,7 +143,7 @@ Jib automatically builds for the local platform or the first specified platform.
      "mcpServers": {
        "solr-search-mcp": {
          "command": "java",
-         "args": ["-jar", "/absolute/path/to/solr-mcp-1.0.0-SNAPSHOT.jar"]
+         "args": ["-jar", "/absolute/path/to/solr-mcp-1.0.0.jar"]
        }
      }
    }
@@ -167,7 +167,7 @@ Jib automatically builds for the local platform or the first specified platform.
 1. **Test server manually**
    ```bash
    # STDIO mode - should start without errors
-   java -jar build/libs/solr-mcp-1.0.0-SNAPSHOT.jar
+   java -jar build/libs/solr-mcp-1.0.0.jar
 
    # HTTP mode
    curl http://localhost:8080/actuator/health
@@ -334,12 +334,12 @@ rm -rf .gradle
 1. **Increase JVM heap**
    ```bash
    export JAVA_OPTS="-Xmx2g -Xms512m"
-   java $JAVA_OPTS -jar build/libs/solr-mcp-1.0.0-SNAPSHOT.jar
+   java $JAVA_OPTS -jar build/libs/solr-mcp-1.0.0.jar
    ```
 
 2. **Docker container limits**
    ```bash
-   docker run -m 2g --rm solr-mcp:1.0.0-SNAPSHOT
+   docker run -m 2g --rm solr-mcp:1.0.0
    ```
 
 3. **Check for memory leaks**
@@ -383,7 +383,7 @@ rm -rf .gradle
 lsof -ti:8080 | xargs kill -9
 
 # Or change port
-java -Dserver.port=8081 -jar build/libs/solr-mcp-1.0.0-SNAPSHOT.jar
+java -Dserver.port=8081 -jar build/libs/solr-mcp-1.0.0.jar
 ```
 
 ## Getting Help

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "docker",
       "identifier": "ghcr.io/apache/solr-mcp-server",
-      "version": "1.0.0-SNAPSHOT",
+      "version": "1.0.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
     {
       "registryType": "docker",
       "identifier": "ghcr.io/apache/solr-mcp-server",
-      "version": "1.0.0-SNAPSHOT",
+      "version": "1.0.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:8080/mcp"


### PR DESCRIPTION
## Summary

- Bump Gradle project version from `1.0.0-SNAPSHOT` to `1.0.0` in `build.gradle.kts`
- Drop `-SNAPSHOT` from `server.json` MCP package versions (stdio + streamable-http)
- Refresh `AGENTS.md` status line to `v1.0.0` (also clears the stale `v0.0.2` reference)
- Update jar filenames (`solr-mcp-1.0.0.jar`) and example Docker tags (`solr-mcp:1.0.0`) in `README.md` and `dev-docs/{DEPLOYMENT,DEVELOPMENT,TROUBLESHOOTING}.md`

Workflow files and `dev-docs/{WORKFLOWS,DOCKER_PUBLISHING}.md` are intentionally untouched — their remaining `SNAPSHOT` references describe the `VERSION-SNAPSHOT-SHA` main-branch image-tag scheme, not the current project version.

## Test plan

- [x] `./gradlew build` passes locally (50s, BUILD SUCCESSFUL)
- [ ] CI build passes
- [ ] Tag `v1.0.0-rc1` and run the ASF release workflow once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)