### PR TITLE
fix(test): stop double-appending docker image tag suffix

### DIFF
--- a/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageHttpIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageHttpIntegrationTest.java
@@ -94,8 +94,7 @@ class DockerImageHttpIntegrationTest {
 	private static final Logger log = LoggerFactory.getLogger(DockerImageHttpIntegrationTest.class);
 
 	// Docker image name and tag from build-info.properties
-	private static final String DOCKER_IMAGE = BuildInfoReader.getDockerImageName()
-			+ System.getProperty("solr.mcp.docker.image.tag.suffix", "");
+	private static final String DOCKER_IMAGE = BuildInfoReader.getDockerImageName();
 	private static final String SOLR_IMAGE = System.getProperty("solr.test.image");
 	private static final int HTTP_PORT = 8080;
 

--- a/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageMcpClientStdioIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageMcpClientStdioIntegrationTest.java
@@ -51,8 +51,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class DockerImageMcpClientStdioIntegrationTest extends McpClientIntegrationTestBase {
 
-	private static final String DOCKER_IMAGE = BuildInfoReader.getDockerImageName()
-			+ System.getProperty("solr.mcp.docker.image.tag.suffix", "");
+	private static final String DOCKER_IMAGE = BuildInfoReader.getDockerImageName();
 
 	@Container
 	static final SolrContainer solrContainer = new SolrContainer(

--- a/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageStdioIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageStdioIntegrationTest.java
@@ -84,8 +84,7 @@ class DockerImageStdioIntegrationTest {
 	private static final Logger log = LoggerFactory.getLogger(DockerImageStdioIntegrationTest.class);
 
 	// Docker image name and tag from build-info.properties
-	private static final String DOCKER_IMAGE = BuildInfoReader.getDockerImageName()
-			+ System.getProperty("solr.mcp.docker.image.tag.suffix", "");
+	private static final String DOCKER_IMAGE = BuildInfoReader.getDockerImageName();
 	private static final String SOLR_IMAGE = System.getProperty("solr.test.image");
 
 	// Network for container communication


### PR DESCRIPTION
## Summary
- The three Docker integration tests in `src/test/java/org/apache/solr/mcp/server/containerization/` built `DOCKER_IMAGE` as `BuildInfoReader.getDockerImageName() + System.getProperty("solr.mcp.docker.image.tag.suffix", "")`, but `BuildInfoReader.getDockerImageName()` already honors that same system property internally. The suffix was therefore applied twice — e.g. `solr-mcp:1.0.0-SNAPSHOT-native-stdio-native-stdio` — and the local Docker daemon 404'd on the pull.
- `DockerImageMcpClientStdioIntegrationTest` showed the same root cause as a 20-second `initialize()` timeout: its `docker run` subprocess exited immediately (no such tag) before any JSON-RPC `initialize` could be sent.
- Fix: drop the caller-side concatenation in all three tests so the tag matches what Paketo actually produced.

## Test plan
- [x] `./gradlew spotlessApply build` green locally
- [ ] `./gradlew dockerIntegrationTest -Pnative` succeeds (native-stdio variant) — needs committer-approved CI run on the fork PR
- [ ] `./gradlew dockerIntegrationTest -Pnative -Pprofile=http` succeeds (native-http variant)
- [ ] `./gradlew dockerIntegrationTest` (Jib JVM) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)