### PR TITLE
ci: drop GHCR/Docker publishing from build-and-publish.yml

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,20 +18,20 @@
 # ║                           (Development Builds)                             ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 #
-# PURPOSE: Automated development builds and Docker image publishing for CI/CD
+# PURPOSE: Automated development build + test (incl. Solr-version matrix) on main
 #
 # WHEN TO USE:
 # -----------
-# ✅ Automatic on every merge to main
-# ✅ Development/testing Docker images
-# ❌ DO NOT use for official ASF releases (use release-publish.yml instead)
+# ✅ Automatic build + test on every merge to main
+# ✅ Solr-version compatibility checks
+# ℹ️  Does not publish images; official ASF releases use release-publish.yml
 #
 # COMPARISON WITH OTHER WORKFLOWS:
 # --------------------------------
 # build-and-publish.yml (THIS FILE):
-#   - Purpose: Development CI/CD
-#   - Trigger: Automatic (push)
-#   - Docker Hub: Personal namespace
+#   - Purpose: Development CI (build + test)
+#   - Trigger: Automatic (push to main)
+#   - Publishes: No (build + test only)
 #   - ASF Vote: Not required
 #   - Use for: Daily development work
 #
@@ -56,54 +56,36 @@
 #
 # ────────────────────────────────────────────────────────────────────────────
 #
-# GitHub Actions Workflow: Build and Publish
-# ===========================================
+# GitHub Actions Workflow: Build and Test
+# ========================================
 #
-# This workflow builds the Solr MCP Server project and publishes Docker images
-# to both GitHub Container Registry (GHCR) and Docker Hub.
+# This workflow builds the Solr MCP Server project and runs its test suite,
+# including the Solr-version compatibility matrix. It does not publish any
+# artifacts — image/release publishing (when needed) is handled separately.
 #
 # Workflow Triggers:
 # ------------------
-# 1. Push to 'main' branch - Builds, tests, and publishes Docker images
-# 2. Version tags (v*) - Builds and publishes release images with version tags
-# 3. Manual trigger via workflow_dispatch
+# 1. Push to 'main' branch - Builds and tests
+# 2. Manual trigger via workflow_dispatch
 #
-# Note: Pull request validation is handled by ci.yml
+# Note: Pull request validation is handled by ci.yml. Release artifact
+# publishing is handled by release-publish.yml.
 #
 # Jobs:
 # -----
 # 1. build: Compiles the JAR, runs tests, and uploads artifacts
-# 2. publish-docker: Publishes multi-platform Docker images using Jib
-#
-# Published Images:
-# ----------------
-# - GitHub Container Registry: ghcr.io/OWNER/solr-mcp:TAG
-# - Docker Hub: DOCKERHUB_USERNAME/solr-mcp:TAG
-#
-# Image Tagging Strategy:
-# ----------------------
-# - Main branch: VERSION-SHORT_SHA (e.g., 1.0.0-SNAPSHOT-a1b2c3d) + latest
-# - Version tags: VERSION (e.g., 1.0.0) + latest
-#
-# Required Secrets (for Docker Hub):
-# ----------------------------------
-# - DOCKERHUB_USERNAME: Your Docker Hub username
-# - DOCKERHUB_TOKEN: Docker Hub access token (https://hub.docker.com/settings/security)
-#
-# Note: GitHub Container Registry uses GITHUB_TOKEN automatically (no setup needed)
+# 2. solr-compatibility: Runs the test suite across supported Solr versions
 
-name: Build and Publish
+name: Build and Test
 
 # Triggers for this workflow
-# - push: runs on commits to main and on version tags (v*)
+# - push: runs on commits to main
 # - workflow_dispatch: allows manual execution from the Actions UI
 # Pull request validation is handled separately by ci.yml
 on:
     push:
         branches:
-            - main            # Build + publish dev images on main merges
-        tags:
-            - 'v*'            # CAUTION (ASF): tag pushes will publish images; prefer using release-publish.yml for post-vote releases
+            - main            # Build + test on main merges
     workflow_dispatch:        # Manual runs for maintainers
 
 jobs:
@@ -216,179 +198,3 @@ jobs:
                 env:
                     SOLR_VERSION: ${{ matrix.solr-version }}
                 run: ./gradlew test "-Dsolr.test.image=solr:${SOLR_VERSION}"
-
-    # ============================================================================
-    # Job 3: Publish Docker Images
-    # ============================================================================
-    # This job builds multi-platform Docker images using Jib and publishes them
-    # to GitHub Container Registry (GHCR) and Docker Hub.
-    #
-    # This job:
-    # - Only runs after 'build' job succeeds (needs: build)
-    # - Skips for pull requests (only runs on push to main and tags)
-    # - Uses Jib to build without requiring Docker daemon
-    # - Supports multi-platform: linux/amd64 and linux/arm64
-    # - Publishes to both GHCR (always) and Docker Hub (if secrets configured)
-    #
-    # Security Note:
-    # - Secrets are passed to Jib CLI arguments for authentication
-    # - This is required for registry authentication and is handled securely
-    # - GitHub Actions masks secret values in logs automatically
-    # ============================================================================
-    publish-docker:
-        name: Publish Docker Images
-        runs-on: ubuntu-latest
-        needs: build  # Wait for build job to complete successfully
-        # Conditional: do not publish images for pull_request events to avoid leaking credentials or pushing unvetted builds
-        if: github.event_name != 'pull_request'  # Skip for PRs
-
-        # Grant permissions for GHCR publishing
-        # contents:read - Read repository contents
-        # packages:write - Publish to GitHub Container Registry
-        permissions:
-            contents: read
-            packages: write
-
-        steps:
-            # Checkout the repository code
-            -   name: Checkout code
-                uses: actions/checkout@v4
-
-            # Set up Java environment using centralized configuration
-            # See .github/actions/setup-java/action.yml to update Java version
-            -   name: Set up Java
-                uses: ./.github/actions/setup-java
-
-            # Extract version and determine image tags
-            # Outputs:
-            # - version: Project version from build.gradle.kts
-            # - tags: Comma-separated list of Docker tags to apply
-            # - is_release: Whether this is a release build (from version tag)
-            -   name: Extract metadata
-                id: meta
-                run: |
-                    # Get version from build.gradle.kts
-                    VERSION=$(grep '^version = ' build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
-                    echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-                    # Determine image tags based on trigger type
-                    if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-                      # For version tags (e.g., v1.0.0), use semantic version
-                      TAG_VERSION=${GITHUB_REF#refs/tags/v}
-                      echo "tags=$TAG_VERSION,latest" >> $GITHUB_OUTPUT
-                      echo "is_release=true" >> $GITHUB_OUTPUT
-                    else
-                      # For main branch, append short commit SHA for traceability
-                      SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
-                      echo "tags=$VERSION-$SHORT_SHA,latest" >> $GITHUB_OUTPUT
-                      echo "is_release=false" >> $GITHUB_OUTPUT
-                    fi
-
-            # Authenticate to GitHub Container Registry
-            # Uses built-in GITHUB_TOKEN (no configuration needed)
-            -   name: Log in to GitHub Container Registry
-                uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 (ASF-allow-listed, no expiry)
-                with:
-                    registry: ghcr.io
-                    username: ${{ github.actor }}
-                    password: ${{ secrets.GITHUB_TOKEN }}
-
-            # Authenticate to Docker Hub
-            # Requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets
-            # This step will fail silently if secrets are not configured
-            #     Create a Docker Hub access token, then add two GitHub Actions secrets named `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.
-            #
-            #          Steps (web UI)
-            #      -   Create Docker Hub token:
-            #              - Visit `https://hub.docker.com`
-            #              - Account → Settings → Security → New Access Token
-            #              - Copy the generated token (you can’t view it again).
-            #      -   Add secrets to the repository:
-            #              - In GitHub, open the repo → `Settings` → `Secrets and variables` → `Actions` → `New repository secret`
-            #              - Add secret `DOCKERHUB_USERNAME` with your Docker Hub username.
-            #              - Add secret `DOCKERHUB_TOKEN` with the token from Docker Hub.
-            #
-            #          Optional
-            #      -   To make secrets available to multiple repos, add them at the organization level: Org → `Settings` → `Secrets and variables` → `Actions`.
-            #      - You can also add environment-level secrets if you use GitHub Environments.
-            #
-            #          CLI example (GitHub CLI)
-            #          ```bash
-            #          gh secret set DOCKERHUB_USERNAME --body "your-docker-username"
-            #          gh secret set DOCKERHUB_TOKEN --body "your-docker-access-token"
-            #          ```
-            #
-            #      Note: `GITHUB_TOKEN` is provided automatically for GHCR; do not store it manually.
-            #      - name: Log in to Docker Hub
-            #        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 (ASF-allow-listed, no expiry)
-            #        with:
-            #          username: ${{ secrets.DOCKERHUB_USERNAME }}
-            #          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-            # Convert repository owner to lowercase
-            # Required because container registry names must be lowercase
-            # Example: "Apache" -> "apache"
-            -   name: Determine repository owner (lowercase)
-                id: repo
-                run: |
-                    echo "owner_lc=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-
-            # Build and publish images to GitHub Container Registry
-            # Uses Jib Gradle plugin to build multi-platform images
-            # Jib creates optimized, layered images without Docker daemon
-            # Each tag is built and pushed separately
-            -   name: Build and publish to GitHub Container Registry
-                run: |
-                    TAGS="${{ steps.meta.outputs.tags }}"
-                    IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
-
-                    # Build and push each tag to GHCR
-                    # Jib automatically handles multi-platform builds (amd64, arm64)
-                    for TAG in "${TAG_ARRAY[@]}"; do
-                      echo "Building and pushing ghcr.io/${{ steps.repo.outputs.owner_lc }}/solr-mcp:$TAG"
-                      ./gradlew jib \
-                        -Djib.to.image=ghcr.io/${{ steps.repo.outputs.owner_lc }}/solr-mcp:$TAG \
-                        -Djib.to.auth.username=${{ github.actor }} \
-                        -Djib.to.auth.password=${{ secrets.GITHUB_TOKEN }}
-                    done
-
-            # Build and publish images to Docker Hub
-            # Only runs if Docker Hub secrets are configured
-            # Gracefully skips if secrets are not available
-            -   name: Build and publish to Docker Hub
-                if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
-                run: |
-                    TAGS="${{ steps.meta.outputs.tags }}"
-                    IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
-
-                    # Build and push each tag to Docker Hub
-                    for TAG in "${TAG_ARRAY[@]}"; do
-                      echo "Building and pushing ${{ secrets.DOCKERHUB_USERNAME }}/solr-mcp:$TAG"
-                      ./gradlew jib \
-                        -Djib.to.image=${{ secrets.DOCKERHUB_USERNAME }}/solr-mcp:$TAG \
-                        -Djib.to.auth.username=${{ secrets.DOCKERHUB_USERNAME }} \
-                        -Djib.to.auth.password=${{ secrets.DOCKERHUB_TOKEN }}
-                    done
-
-            # Create a summary of published images
-            # Displayed in the GitHub Actions workflow summary page
-            # Makes it easy to see which images were published and their tags
-            -   name: Summary
-                run: |
-                    echo "### Docker Images Published :rocket:" >> $GITHUB_STEP_SUMMARY
-                    echo "" >> $GITHUB_STEP_SUMMARY
-                    echo "#### GitHub Container Registry" >> $GITHUB_STEP_SUMMARY
-                    TAGS="${{ steps.meta.outputs.tags }}"
-                    IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
-                    for TAG in "${TAG_ARRAY[@]}"; do
-                      echo "- \`ghcr.io/${{ steps.repo.outputs.owner_lc }}/solr-mcp:$TAG\`" >> $GITHUB_STEP_SUMMARY
-                    done
-
-                    # Only show Docker Hub section if secrets are configured
-                    if [[ "${{ secrets.DOCKERHUB_USERNAME }}" != "" ]]; then
-                      echo "" >> $GITHUB_STEP_SUMMARY
-                      echo "#### Docker Hub" >> $GITHUB_STEP_SUMMARY
-                      for TAG in "${TAG_ARRAY[@]}"; do
-                        echo "- \`${{ secrets.DOCKERHUB_USERNAME }}/solr-mcp:$TAG\`" >> $GITHUB_STEP_SUMMARY
-                      done
-                    fi


### PR DESCRIPTION
## Problem

`build-and-publish.yml` has **never had a successful run** — it fails at *startup* with **zero jobs executed**, on every push to `main` and (as attributed) on every PR.

Root cause: the `publish-docker` job uses `docker/login-action`, a third‑party action that is **not on the Apache org's GitHub Actions allow‑list**. Allow‑list rejection happens at workflow‑parse time, *before* the job's `if: github.event_name != 'pull_request'` guard is ever evaluated — so a publish job that wouldn't even run on PRs still takes the **entire workflow** down at startup, killing the `build` and `solr-compatibility` (Solr‑version matrix) jobs along with it.

A prior fix (#145) SHA‑pinned the action to `650006c6…` (v4.2.0) on the assumption it was allow‑listed, but the workflow still never starts — unlike `native.yml`, whose graalvm pin (`329c42c`) genuinely is allow‑listed and now runs.

## Fix

We do **not** publish images from this workflow (releases are handled by `release-publish.yml`), so rather than reauthenticate to a registry we don't use, this removes the publishing entirely:

- **Remove the `publish-docker` job** (GHCR login + Jib push to GHCR/Docker Hub + summary) — this deletes the allow‑list‑blocking `docker/login-action` reference.
- **Rename** the workflow `Build and Publish` → `Build and Test` (it no longer publishes).
- **Drop the `tags: 'v*'` trigger**, which existed only to publish release images.
- **Update the header docs** to reflect build + test; comparison notes for `release-publish.yml` / `nightly-build.yml` are left intact.

Net: `20 insertions, 214 deletions`, one file.

## Result

The workflow file now parses, so the next push to `main` runs `build` + `solr-compatibility` — the first green this workflow can produce. Because the (valid) `on:` block has no `pull_request` trigger, it will run on **main pushes + manual dispatch only** and stop appearing as a red ✗ on PRs; PR validation remains with `ci.yml`.

## Notes

- `release-publish.yml` still references the same `docker/login-action@650006c6…` in two GHCR‑login steps. It's dormant (manual release trigger), so it isn't failing anything today, but it will hit the same startup failure whenever a release is run — worth a follow‑up (there the fix is an inline `docker login`, since releases do need to publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
