### PR TITLE
ci: log in to GHCR inline in release-publish.yml (bypass ASF Actions allow-list)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -402,12 +402,16 @@ jobs:
         run: |
           sed -i "s/version = \".*\"/version = \"${RELEASE_VERSION}\"/" build.gradle.kts
 
+      # Inline `docker login` rather than docker/login-action: that third-party
+      # action is not on the ASF GitHub Actions allow-list, which fails the whole
+      # workflow at startup. The token is piped via stdin (never on the command
+      # line or in logs) and the username is read from an env var, so no untrusted
+      # value is interpolated into the run script.
       - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 (ASF-allow-listed, no expiry)
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
       # Refuse to overwrite an already-published version tag. Moving tags
       # (latest-*) are mutable and assembled later; per-version tags are not.
@@ -451,12 +455,16 @@ jobs:
       contents: read
       packages: write
     steps:
+      # Inline `docker login` rather than docker/login-action: that third-party
+      # action is not on the ASF GitHub Actions allow-list, which fails the whole
+      # workflow at startup. The token is piped via stdin (never on the command
+      # line or in logs) and the username is read from an env var, so no untrusted
+      # value is interpolated into the run script.
       - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 (ASF-allow-listed, no expiry)
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
       - name: Create version manifest lists
         env:


### PR DESCRIPTION
## Problem

`release-publish.yml` authenticates to GHCR with `docker/login-action` in two GHCR‑login steps. That third‑party action is **not on the Apache org's GitHub Actions allow‑list**, and allow‑list rejection happens at workflow‑parse time — so the action fails the **entire workflow at startup** (zero jobs run) the moment a release is run.

The SHA‑pin to `650006c6…` (v4.2.0) added in #145 does not help: that SHA isn't allow‑listed. (The `graalvm/setup-graalvm@329c42c…` pin in the same file *is* allow‑listed and is left untouched.)

This workflow is dormant today (manual release trigger), so it isn't failing CI now — but it would startup‑fail the first time someone cuts a release.

## Fix

Unlike #153 (where `build-and-publish.yml` doesn't publish, so the job was removed), `release-publish.yml` genuinely needs to publish — so it keeps the login, just **inline**:

- Replace both `docker/login-action` GHCR‑login steps with an inline `docker login ghcr.io` using the built‑in `GITHUB_TOKEN`.
- Token is piped via **stdin** (`--password-stdin`) so it never appears on the command line or in logs; the username is read from an `env:` var, so **no untrusted value is interpolated** into the `run:` script.

This removes the allow‑list dependency entirely — the inline `docker login` uses only the Docker CLI already on the runner.

`18 insertions, 10 deletions`, one file. No publish behavior changes — the subsequent Jib push steps and Docker Hub publishing are untouched.

## Companion PR

This is the follow‑up to #153 (which fixed `build-and-publish.yml` by removing its unused publish job). Together they clear `docker/login-action` from both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
