### PR TITLE
feat(search): document eDisMax local params in search tool description

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -229,6 +229,10 @@ public class SearchService {
 			annotations = @McpTool.McpAnnotations(readOnlyHint = true),
 			description = """
 			Search specified Solr collection with query, optional filters, facets, sorting, and pagination.
+			The q parameter accepts Lucene query syntax. There are no separate defType/qf/mm parameters:
+			to use eDisMax features (multi-field search, minimum-match, boosts), embed Solr local params
+			in q, e.g. {!edismax qf='name author' mm=2}george martin.
+			Put filters in fq (filterQueries) instead of q so Solr can cache and reuse them.
 			Note that solr has dynamic fields where name of field in schema may end with suffixes
 			_s: Represents a string field, used for exact string matching.
 			_i: Represents an integer field.
@@ -256,9 +260,12 @@ public class SearchService {
 	// @formatter:on
 	public SearchResponse search(@McpToolParam(description = "Solr collection to query") String collection,
 			@McpToolParam(
-					description = "Solr q parameter. If none specified defaults to \"*:*\"",
+					description = "Solr q parameter. Lucene syntax; supports local params such as"
+							+ " {!edismax qf='name author'}. If none specified defaults to \"*:*\"",
 					required = false) String query,
-			@McpToolParam(description = "Solr fq parameter", required = false) List<String> filterQueries,
+			@McpToolParam(
+					description = "Solr fq parameter: list of filter queries, one filter per entry",
+					required = false) List<String> filterQueries,
 			@McpToolParam(description = "Solr facet fields", required = false) List<String> facetFields,
 			@McpToolParam(description = "Solr sort parameter", required = false) List<Map<String, String>> sortClauses,
 			@McpToolParam(description = "Starting offset for pagination", required = false) Integer start,


### PR DESCRIPTION
## Motivation

The `search` tool intentionally exposes a narrow surface: `q`, `fq`, field facets, sort, and paging. LLM clients that know Solr look for `defType`/`qf`/`mm` tool parameters, find none, and typically fall back to plain single-field term queries — losing multi-field search, minimum-match, and boosting entirely.

Solr already supports all of that through **local params embedded in `q`** (e.g. `{!edismax qf='name author' mm=2}george martin`), but nothing on the tool surface tells the client this. A tool description is the right home for this fact: it ships to every MCP client and is read exactly at call-construction time.

## Changes

- `search` tool description: note that there are no separate `defType`/`qf`/`mm` parameters and show the local-params form for eDisMax features.
- `query` param description: mention Lucene syntax + local params support.
- `filterQueries` param description: clarify one filter per entry and that filters belong in `fq` for cacheability.

Description-only change — no behavior change. `./gradlew build` passes (unit + Testcontainers integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)