### PR TITLE
feat(mcp): declare tool-surface boundaries in MCP server instructions

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,12 @@
 #
 spring.application.name=solr-mcp
 spring.profiles.active=${PROFILES:stdio}
-spring.ai.mcp.server.instructions=This server provides tools to interact with Apache Solr using Model Context Protocol (MCP) over STDIO and/or HTTP. 
+spring.ai.mcp.server.instructions=This server provides tools to search, index, and manage Apache Solr collections. \
+Discover before acting: use list-collections and get-schema to see what exists before searching or indexing. \
+Surface boundaries: there are no tools to delete documents or collections, drop or alter existing fields, \
+or debug relevance scoring (debugQuery); vector/KNN search is not exposed; search facets are simple field \
+facets only (no range, pivot, or JSON facets). Schema modification is additive only via add-fields and \
+add-field-types; changing an existing field's type requires reindexing and is not supported by this server.
 spring.ai.mcp.server.name=${spring.application.name}
 spring.ai.mcp.server.version=1.0.0
 # Solr configuration


### PR DESCRIPTION
## Motivation

`spring.ai.mcp.server.instructions` currently carries a generic one-liner. The MCP `initialize` response delivers these instructions to **every** client, making them the right home for surface-wide facts that no individual tool description can own.

Without them, LLM clients that know Solr well tend to hunt for tools that don't exist (delete-documents, debug-query, KNN search) or attempt unsupported operations (changing an existing field's type). Declaring the boundaries up front lets clients route around gaps instead of failing into them.

## Changes

Rewrites the instructions to declare:
- discover-before-acting guidance (`list-collections`, `get-schema` first)
- what the surface does **not** include: no delete tools, no field drop/alter, no debugQuery, no vector/KNN, field facets only
- schema modification is additive only (`add-fields`, `add-field-types`); type changes require reindexing elsewhere

Property-value-only change — no code touched. `./gradlew build` passes (unit + Testcontainers integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)