### PR TITLE
docs(collection): explain null cache/handler stats on Solr 10 in tool description

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -504,7 +504,9 @@ public class CollectionService {
 	@McpTool(
 			name = "get-collection-stats",
 			annotations = @McpTool.McpAnnotations(readOnlyHint = true),
-			description = "Get stats/metrics on a Solr collection")
+			description = "Get stats/metrics on a Solr collection. On Solr 10+ cacheStats and"
+					+ " handlerStats are always null because the /admin/mbeans endpoint was removed"
+					+ " from Solr; this is expected and not an error.")
 	public SolrMetrics getCollectionStats(
 			@McpToolParam(description = "Solr collection to get stats/metrics for") String collection)
 			throws SolrServerException, IOException {


### PR DESCRIPTION
## Motivation

On Solr 10, `/admin/mbeans` was removed; `get-collection-stats` already degrades gracefully and returns `null` for `cacheStats`/`handlerStats`. But nothing on the tool surface tells the client this is expected — an LLM client sees unexplained nulls and may retry, misreport a broken server, or go hunting for a workaround.

A bare `null` a client must interpret is a documentation gap in the place clients actually look: the tool description.

## Changes

- `get-collection-stats` description now states that on Solr 10+ the two stats are always null because the endpoint was removed from Solr, and that this is expected.

Deliberately scoped to the description only: PR #111 is already modifying the `fetchCacheMetrics`/`fetchHandlerMetrics` catch clauses, and this avoids conflicting with it. A follow-up could migrate to `/admin/metrics` to restore the stats on Solr 10.

Description-only change — no behavior change. `./gradlew build` passes (unit + Testcontainers integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)