### PR TITLE
feat(search): append remediation hints to common Solr query errors

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -513,7 +513,8 @@ public class CollectionService {
 
 		// Validate collection exists
 		if (!validateCollectionExists(actualCollection)) {
-			throw new IllegalArgumentException(COLLECTION_NOT_FOUND_ERROR + actualCollection);
+			throw new IllegalArgumentException(COLLECTION_NOT_FOUND_ERROR + actualCollection
+					+ ". Hint: call list-collections to see available collections.");
 		}
 
 		// Index statistics using Luke

--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -114,6 +114,38 @@ public class SearchService {
 	 * map.
 	 */
 	public static final String SORT_ORDER = "order";
+
+	/**
+	 * Fragments of Solr's own error text that identify a failure we can advise on.
+	 *
+	 * <p>
+	 * These are matched rather than imported because they are produced by
+	 * <em>solr-core</em>, which is not on this server's classpath — only
+	 * {@code solr-solrj} is. Nothing couples them to Solr at compile time, so
+	 * {@code SearchServiceIntegrationTest} pins each one against a real Solr
+	 * server: if a future Solr rewords a message, that test fails rather than the
+	 * hint silently disappearing. Prefer a structured signal (see
+	 * {@link SolrException#code()} below) whenever one exists.
+	 */
+	static final String UNDEFINED_FIELD_TOKEN = "undefined field";
+	/** @see #UNDEFINED_FIELD_TOKEN */
+	static final String SORT_FIELD_NOT_FOUND_TOKEN = "field can't be found";
+	/** @see #UNDEFINED_FIELD_TOKEN */
+	static final String SYNTAX_ERROR_TOKEN = "syntaxerror";
+	/** @see #UNDEFINED_FIELD_TOKEN */
+	static final String CANNOT_PARSE_TOKEN = "cannot parse";
+
+	/**
+	 * Remediation hint naming the {@code get-schema} tool; takes the collection.
+	 */
+	static final String GET_SCHEMA_HINT_FORMAT = ". Hint: call get-schema on collection '%s' to see the fields that"
+			+ " exist; schemaless collections often store values under dynamic-suffix names such as name_s or price_d.";
+	/** Remediation hint for an unparseable {@code q}. */
+	static final String LUCENE_SYNTAX_HINT = ". Hint: the q parameter uses Lucene query syntax; quote or escape"
+			+ " special characters and check any {!...} local params.";
+	/** Remediation hint naming the {@code list-collections} tool. */
+	static final String LIST_COLLECTIONS_HINT = ". Hint: call list-collections to see available collections.";
+
 	private final SolrClient solrClient;
 
 	/**
@@ -334,20 +366,24 @@ public class SearchService {
 	 *         or the original exception when no hint applies
 	 */
 	private static RuntimeException withRemediationHint(SolrException e, String collection) {
-		String message = String.valueOf(e.getMessage());
-		String lower = message.toLowerCase(Locale.ROOT);
-		if (lower.contains("undefined field") || lower.contains("field can't be found")) {
-			return new IllegalArgumentException(message + ". Hint: call get-schema on collection '" + collection
-					+ "' to see the fields that exist; schemaless collections often store values under"
-					+ " dynamic-suffix names such as name_s or price_d.", e);
+		final String message = String.valueOf(e.getMessage());
+
+		// An unknown collection is a 404 whose body is Solr's HTML "not found" page,
+		// so SolrJ reports it as a mime-type mismatch and leaves getMetadata() null.
+		// The status code is the only signal that survives; match it rather than the
+		// message text, which mentions neither the collection nor "404".
+		if (e.code() == SolrException.ErrorCode.NOT_FOUND.code) {
+			return new IllegalArgumentException(message + LIST_COLLECTIONS_HINT, e);
 		}
-		if (lower.contains("syntaxerror") || lower.contains("cannot parse")) {
-			return new IllegalArgumentException(message + ". Hint: the q parameter uses Lucene query syntax;"
-					+ " quote or escape special characters and check any {!...} local params.", e);
+
+		// Everything below is a 400 carrying a generic SolrException, indistinguishable
+		// except by Solr's message text.
+		final String lower = message.toLowerCase(Locale.ROOT);
+		if (lower.contains(UNDEFINED_FIELD_TOKEN) || lower.contains(SORT_FIELD_NOT_FOUND_TOKEN)) {
+			return new IllegalArgumentException(message + GET_SCHEMA_HINT_FORMAT.formatted(collection), e);
 		}
-		if (lower.contains("collection not found") || lower.contains("can not find") || lower.contains("404")) {
-			return new IllegalArgumentException(message + ". Hint: call list-collections to see available collections.",
-					e);
+		if (lower.contains(SYNTAX_ERROR_TOKEN) || lower.contains(CANNOT_PARSE_TOKEN)) {
+			return new IllegalArgumentException(message + LUCENE_SYNTAX_HINT, e);
 		}
 		return e;
 	}

--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -29,6 +30,7 @@ import org.apache.solr.client.solrj.response.FacetField;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.mcp.server.util.PromptNames;
 import org.springaicommunity.mcp.annotation.McpArg;
@@ -300,7 +302,12 @@ public class SearchService {
 			solrQuery.setRows(rows);
 		}
 
-		final QueryResponse queryResponse = solrClient.query(collection, solrQuery);
+		final QueryResponse queryResponse;
+		try {
+			queryResponse = solrClient.query(collection, solrQuery);
+		} catch (SolrException e) {
+			throw withRemediationHint(e, collection);
+		}
 
 		// Add documents
 		final SolrDocumentList documents = queryResponse.getResults();
@@ -312,6 +319,37 @@ public class SearchService {
 		final var facets = getFacets(queryResponse);
 
 		return new SearchResponse(documents.getNumFound(), documents.getStart(), documents.getMaxScore(), docs, facets);
+	}
+
+	/**
+	 * Wraps common Solr query failures with a next-step hint. MCP clients receive
+	 * the exception message as the tool error, so naming the follow-up tool lets
+	 * them self-correct instead of retrying blind.
+	 *
+	 * @param e
+	 *            the Solr exception raised by the query
+	 * @param collection
+	 *            the collection that was queried
+	 * @return an exception carrying the original message plus a remediation hint,
+	 *         or the original exception when no hint applies
+	 */
+	private static RuntimeException withRemediationHint(SolrException e, String collection) {
+		String message = String.valueOf(e.getMessage());
+		String lower = message.toLowerCase(Locale.ROOT);
+		if (lower.contains("undefined field") || lower.contains("field can't be found")) {
+			return new IllegalArgumentException(message + ". Hint: call get-schema on collection '" + collection
+					+ "' to see the fields that exist; schemaless collections often store values under"
+					+ " dynamic-suffix names such as name_s or price_d.", e);
+		}
+		if (lower.contains("syntaxerror") || lower.contains("cannot parse")) {
+			return new IllegalArgumentException(message + ". Hint: the q parameter uses Lucene query syntax;"
+					+ " quote or escape special characters and check any {!...} local params.", e);
+		}
+		if (lower.contains("collection not found") || lower.contains("can not find") || lower.contains("404")) {
+			return new IllegalArgumentException(message + ". Hint: call list-collections to see available collections.",
+					e);
+		}
+		return e;
 	}
 
 	/**

--- a/src/test/java/org/apache/solr/mcp/server/search/SearchServiceIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/search/SearchServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import java.util.OptionalDouble;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.mcp.server.TestcontainersConfiguration;
 import org.apache.solr.mcp.server.indexing.IndexingService;
 import org.junit.jupiter.api.BeforeEach;
@@ -184,11 +185,91 @@ class SearchServiceIntegrationTest {
 		assertEquals(10, documents.size());
 	}
 
+	/**
+	 * Remediation hints classify Solr's error text, which this server cannot see at
+	 * compile time — the strings are produced by solr-core, and only solr-solrj is
+	 * on the classpath. These tests therefore provoke each failure on a real Solr
+	 * server and assert the hint survives: they are the only thing standing between
+	 * a reworded Solr message and a hint that silently stops appearing.
+	 *
+	 * <p>
+	 * Each asserts on the hint constant, never on the token being matched — an
+	 * assertion routed through the same token the matcher uses would pass even if
+	 * Solr changed its wording, which is exactly the regression being guarded.
+	 */
 	@Test
-	void searchWithUndefinedFieldReturnsRemediationHint() {
+	void searchWithUndefinedFieldInQueryReturnsGetSchemaHint() {
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> searchService
 				.search(COLLECTION_NAME, "definitely_not_a_field:value", null, null, null, null, null));
-		assertTrue(e.getMessage().contains("get-schema"));
+		assertTrue(e.getMessage().contains(SearchService.GET_SCHEMA_HINT_FORMAT.formatted(COLLECTION_NAME)),
+				() -> "expected get-schema hint, got: " + e.getMessage());
+	}
+
+	@Test
+	void searchWithUndefinedFieldInFilterQueryReturnsGetSchemaHint() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> searchService
+				.search(COLLECTION_NAME, "*:*", List.of("definitely_not_a_field:value"), null, null, null, null));
+		assertTrue(e.getMessage().contains(SearchService.GET_SCHEMA_HINT_FORMAT.formatted(COLLECTION_NAME)),
+				() -> "expected get-schema hint, got: " + e.getMessage());
+	}
+
+	/** Faceting words it differently: {@code undefined field: "name"}. */
+	@Test
+	void searchWithUndefinedFacetFieldReturnsGetSchemaHint() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> searchService
+				.search(COLLECTION_NAME, "*:*", null, List.of("definitely_not_a_field"), null, null, null));
+		assertTrue(e.getMessage().contains(SearchService.GET_SCHEMA_HINT_FORMAT.formatted(COLLECTION_NAME)),
+				() -> "expected get-schema hint, got: " + e.getMessage());
+	}
+
+	/**
+	 * Sorting words it differently again: {@code sort param field can't be found},
+	 * which is why the matcher carries a second undefined-field token.
+	 */
+	@Test
+	void searchWithUndefinedSortFieldReturnsGetSchemaHint() {
+		List<Map<String, String>> sort = List
+				.of(Map.of(SearchService.SORT_ITEM, "definitely_not_a_field", SearchService.SORT_ORDER, "asc"));
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> searchService.search(COLLECTION_NAME, "*:*", null, null, sort, null, null));
+		assertTrue(e.getMessage().contains(SearchService.GET_SCHEMA_HINT_FORMAT.formatted(COLLECTION_NAME)),
+				() -> "expected get-schema hint, got: " + e.getMessage());
+	}
+
+	@Test
+	void searchWithUnparseableQueryReturnsLuceneSyntaxHint() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> searchService.search(COLLECTION_NAME, "name:(", null, null, null, null, null));
+		assertTrue(e.getMessage().contains(SearchService.LUCENE_SYNTAX_HINT),
+				() -> "expected Lucene syntax hint, got: " + e.getMessage());
+	}
+
+	/**
+	 * An unknown collection is a 404 whose body is Solr's HTML page, so the message
+	 * names neither the collection nor "404" — it reads
+	 * {@code Expected mime type in
+	 * [application/json, text/plain] but got text/html}. Matched on
+	 * {@link org.apache.solr.common.SolrException#code()} instead.
+	 */
+	@Test
+	void searchOnMissingCollectionReturnsListCollectionsHint() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> searchService.search("definitely_not_a_collection", "*:*", null, null, null, null, null));
+		assertTrue(e.getMessage().contains(SearchService.LIST_COLLECTIONS_HINT),
+				() -> "expected list-collections hint, got: " + e.getMessage());
+	}
+
+	/**
+	 * A Solr error we have no advice for must reach the client untouched. Negative
+	 * {@code rows} is structurally identical to the undefined-field failures — a
+	 * 400 carrying a generic {@code SolrException} — so it also pins that the text
+	 * matching is not over-broad.
+	 */
+	@Test
+	void searchWithUnrecognizedSolrErrorPropagatesWithoutHint() {
+		SolrException e = assertThrows(SolrException.class,
+				() -> searchService.search(COLLECTION_NAME, "*:*", null, null, null, null, -5));
+		assertFalse(e.getMessage().contains("Hint:"), () -> "expected no hint, got: " + e.getMessage());
 	}
 
 	@Test

--- a/src/test/java/org/apache/solr/mcp/server/search/SearchServiceIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/search/SearchServiceIntegrationTest.java
@@ -185,6 +185,13 @@ class SearchServiceIntegrationTest {
 	}
 
 	@Test
+	void searchWithUndefinedFieldReturnsRemediationHint() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> searchService
+				.search(COLLECTION_NAME, "definitely_not_a_field:value", null, null, null, null, null));
+		assertTrue(e.getMessage().contains("get-schema"));
+	}
+
+	@Test
 	void testSearchWithQuery() throws SolrServerException, IOException {
 		SearchResponse result = searchService.search(COLLECTION_NAME, "name:\"Game of Thrones\"", null, null, null,
 				null, null);

--- a/src/test/java/org/apache/solr/mcp/server/search/SearchServiceTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/search/SearchServiceTest.java
@@ -32,6 +32,7 @@ import org.apache.solr.client.solrj.response.FacetField;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
@@ -45,6 +46,41 @@ class SearchServiceTest {
 	void constructor_ShouldInitializeWithSolrClient() {
 		SearchService localService = new SearchService(mock(SolrClient.class));
 		assertNotNull(localService);
+	}
+
+	@Test
+	void search_WithUndefinedField_ShouldHintGetSchema() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class)))
+				.thenThrow(new SolrException(SolrException.ErrorCode.BAD_REQUEST, "undefined field bogus"));
+		SearchService localService = new SearchService(mockClient);
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> localService.search("test_collection", "bogus:x", null, null, null, null, null));
+		assertTrue(e.getMessage().contains("undefined field bogus"));
+		assertTrue(e.getMessage().contains("get-schema"));
+	}
+
+	@Test
+	void search_WithQuerySyntaxError_ShouldHintLuceneSyntax() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenThrow(new SolrException(
+				SolrException.ErrorCode.BAD_REQUEST, "org.apache.solr.search.SyntaxError: Cannot parse 'name:('"));
+		SearchService localService = new SearchService(mockClient);
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> localService.search("test_collection", "name:(", null, null, null, null, null));
+		assertTrue(e.getMessage().contains("Lucene query syntax"));
+	}
+
+	@Test
+	void search_WithUnrelatedSolrError_ShouldPropagateUnchanged() throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class)))
+				.thenThrow(new SolrException(SolrException.ErrorCode.SERVER_ERROR, "internal failure"));
+		SearchService localService = new SearchService(mockClient);
+		SolrException e = assertThrows(SolrException.class,
+				() -> localService.search("test_collection", null, null, null, null, null, null));
+		assertTrue(e.getMessage().contains("internal failure"));
+		assertFalse(e.getMessage().contains("Hint:"));
 	}
 
 	@Test

--- a/src/test/java/org/apache/solr/mcp/server/search/SearchServiceTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/search/SearchServiceTest.java
@@ -48,35 +48,67 @@ class SearchServiceTest {
 		assertNotNull(localService);
 	}
 
+	/*
+	 * These stub Solr's error text rather than observe it, so they can only show
+	 * that a matching message produces a hint — never that Solr still emits such a
+	 * message. The fixture strings below are verbatim samples captured from a real
+	 * Solr 9.9; SearchServiceIntegrationTest is what keeps them honest.
+	 */
+
+	private static SearchService serviceThrowing(SolrException e) throws Exception {
+		SolrClient mockClient = mock(SolrClient.class);
+		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenThrow(e);
+		return new SearchService(mockClient);
+	}
+
 	@Test
 	void search_WithUndefinedField_ShouldHintGetSchema() throws Exception {
-		SolrClient mockClient = mock(SolrClient.class);
-		when(mockClient.query(eq("test_collection"), any(SolrQuery.class)))
-				.thenThrow(new SolrException(SolrException.ErrorCode.BAD_REQUEST, "undefined field bogus"));
-		SearchService localService = new SearchService(mockClient);
+		SearchService localService = serviceThrowing(
+				new SolrException(SolrException.ErrorCode.BAD_REQUEST, "undefined field bogus"));
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
 				() -> localService.search("test_collection", "bogus:x", null, null, null, null, null));
-		assertTrue(e.getMessage().contains("undefined field bogus"));
-		assertTrue(e.getMessage().contains("get-schema"));
+		assertTrue(e.getMessage().contains("undefined field bogus"), "original Solr message must be preserved");
+		assertTrue(e.getMessage().contains(SearchService.GET_SCHEMA_HINT_FORMAT.formatted("test_collection")));
+	}
+
+	@Test
+	void search_WithUndefinedSortField_ShouldHintGetSchema() throws Exception {
+		SearchService localService = serviceThrowing(
+				new SolrException(SolrException.ErrorCode.BAD_REQUEST, "sort param field can't be found: bogus"));
+		List<Map<String, String>> sort = List
+				.of(Map.of(SearchService.SORT_ITEM, "bogus", SearchService.SORT_ORDER, "asc"));
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> localService.search("test_collection", "*:*", null, null, sort, null, null));
+		assertTrue(e.getMessage().contains(SearchService.GET_SCHEMA_HINT_FORMAT.formatted("test_collection")));
 	}
 
 	@Test
 	void search_WithQuerySyntaxError_ShouldHintLuceneSyntax() throws Exception {
-		SolrClient mockClient = mock(SolrClient.class);
-		when(mockClient.query(eq("test_collection"), any(SolrQuery.class))).thenThrow(new SolrException(
-				SolrException.ErrorCode.BAD_REQUEST, "org.apache.solr.search.SyntaxError: Cannot parse 'name:('"));
-		SearchService localService = new SearchService(mockClient);
+		SearchService localService = serviceThrowing(new SolrException(SolrException.ErrorCode.BAD_REQUEST,
+				"org.apache.solr.search.SyntaxError: Cannot parse 'name:('"));
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
 				() -> localService.search("test_collection", "name:(", null, null, null, null, null));
-		assertTrue(e.getMessage().contains("Lucene query syntax"));
+		assertTrue(e.getMessage().contains(SearchService.LUCENE_SYNTAX_HINT));
+	}
+
+	/**
+	 * A missing collection is matched on the 404 status, not the message — Solr's
+	 * 404 body is an HTML page, so SolrJ surfaces it as the mime-type mismatch
+	 * stubbed here, which mentions neither the collection nor "404".
+	 */
+	@Test
+	void search_WithNotFoundStatus_ShouldHintListCollections() throws Exception {
+		SearchService localService = serviceThrowing(new SolrException(SolrException.ErrorCode.NOT_FOUND,
+				"Expected mime type in [application/json, text/plain] but got text/html."));
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> localService.search("test_collection", "*:*", null, null, null, null, null));
+		assertTrue(e.getMessage().contains(SearchService.LIST_COLLECTIONS_HINT));
 	}
 
 	@Test
 	void search_WithUnrelatedSolrError_ShouldPropagateUnchanged() throws Exception {
-		SolrClient mockClient = mock(SolrClient.class);
-		when(mockClient.query(eq("test_collection"), any(SolrQuery.class)))
-				.thenThrow(new SolrException(SolrException.ErrorCode.SERVER_ERROR, "internal failure"));
-		SearchService localService = new SearchService(mockClient);
+		SearchService localService = serviceThrowing(
+				new SolrException(SolrException.ErrorCode.SERVER_ERROR, "internal failure"));
 		SolrException e = assertThrows(SolrException.class,
 				() -> localService.search("test_collection", null, null, null, null, null, null));
 		assertTrue(e.getMessage().contains("internal failure"));


### PR DESCRIPTION
## Motivation

MCP clients receive a tool's exception message verbatim — the error message is effectively part of the tool's API. Today a raw Solr error like `undefined field foo` gives an LLM client nothing actionable, so it retries blind or gives up. An error that names the follow-up tool arrives at exactly the moment of failure, with perfect targeting, and costs zero tokens until something actually fails.

## Changes

`search` wraps `SolrException` from the query and appends a hint for three recognizable failures:

- **undefined field** → call `get-schema`; mentions dynamic-suffix naming (`name_s`, `price_d`). Solr words this three different ways depending on where the field appears: `undefined field x` (`q`/`fq`), `undefined field: "x"` (facet), and `sort param field can't be found: x` (sort).
- **query syntax error** → `q` uses Lucene syntax; quote/escape special characters, check `{!...}` local params
- **collection not found** → call `list-collections`
- anything unrecognized propagates **unchanged**

`CollectionService`'s collection-not-found error appends the same `list-collections` hint (message prefix preserved, so existing assertions still hold).

Solr's match tokens and the hint text are extracted to named constants, matching the convention in `CollectionService` / `PromptNames`.

### Collection-not-found is matched on the status code, not the message

The first revision of this PR matched the message text for `collection not found` / `can not find` / `404`. **That branch never fired against a real server.** An unknown collection is a 404 whose body is Solr's HTML "not found" page, so SolrJ surfaces it as:

```
Expected mime type in [application/json, text/plain] but got text/html. <p>
  Searching for Solr?<br/>
  You must type the correct path.<br/>
  Solr will respond.
</p>
```

— text containing none of the three tokens. The unit test passed only because it asserted against a fixture string this PR invented.

It now matches `SolrException.ErrorCode.NOT_FOUND.code`. The status code is the only signal that survives — `getMetadata()` and `getRootThrowable()` are both `null` for this response, since the body isn't a Solr JSON error — and using SolrJ's own constant also removes the false-positive risk of matching the bare substring `404` anywhere in a message.

## Tests

**Unit** (mocked `SolrClient`): undefined field, undefined sort field, syntax error, not-found status, and an unrelated Solr error propagating without a hint.

**Integration** (Testcontainers, real Solr) — one per branch: undefined field in `q`, `fq`, facet, and sort; unparseable query; missing collection; and negative `rows` asserting no hint is added.

The integration tests aren't redundant with the unit tests — they're the only ones that can fail. These hints classify Solr's error *text*, which is generated by **solr-core**; only `solr-solrj` is on the classpath. Nothing couples the matchers to Solr's wording at compile time, so a mock-based test can only prove that a stubbed message produces a hint, never that Solr still emits such a message — it would keep passing if a future Solr reworded anything. Each integration test therefore asserts on the *hint* constant, never on the token the matcher uses, so no assertion can pass by tautology. Writing them is what surfaced the dead 404 branch above.

Where a structured signal exists it is preferred over text: 404 → `code()`. Undefined-field and bad-param failures are structurally identical (both a 400 carrying a generic `SolrException`), so text matching there is irreducible — hence the tests.

`./gradlew build` passes (unit + Testcontainers integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
