### PR TITLE
docs: correct stale SolrJ 10 dependency note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,7 @@ Remaining known differences from Solr 9:
 - **`/admin/mbeans` removed:** Cache and handler stats from `getCollectionStats()` will always be `null` on Solr 10. A future migration to `/admin/metrics` will restore these metrics.
 - **Metrics migration:** Dropwizard metrics replaced by OpenTelemetry. Metric names switch to snake_case in Solr 10.
 - **SolrJ base URL:** Already uses root URLs — **no change needed**.
-- **SolrJ 10.x dependency:** Not yet on Maven Central (as of 2026-03-06); tests use SolrJ 9.x against a Solr 10 server. Update `solr-solrj` and Jetty BOM when 10.x is released.
+- **SolrJ version:** `solr-solrj` is on 10.0.0 (`gradle/libs.versions.toml`), released to Maven Central and bumped in #58. Jetty artifacts are declared versionless and managed by Spring Boot's BOM, so there is no separate Jetty pin to update. Note the client is *newer* than the default test server: `solr.test.image` defaults to `solr:9.9-slim`, so the standard build exercises a SolrJ 10 client against Solr 9.9.
 
 ## Key Configuration
 

--- a/dev-docs/DEVELOPMENT.md
+++ b/dev-docs/DEVELOPMENT.md
@@ -204,7 +204,8 @@ Tests run against `solr:9.9-slim` by default. Point them at another Solr version
 endpoint was removed in Solr 10, so `getCacheMetrics()`/`getHandlerMetrics()` catch
 `RuntimeException` and return `null` — `cacheStats`/`handlerStats` from `get-collection-stats`
 are therefore always `null` on Solr 10 (a future migration to `/admin/metrics` will restore
-them). SolrJ 10.x is not yet on Maven Central, so tests run SolrJ 9.x against a Solr 10 server.
+them). SolrJ is on 10.0.0; since `solr.test.image` defaults to `solr:9.9-slim`, the standard
+build runs a SolrJ 10 client against a Solr 9.9 server.
 
 ### Test with MCP Inspector
 


### PR DESCRIPTION
## Motivation

The Solr 10 compatibility docs still say:

> **SolrJ 10.x dependency:** Not yet on Maven Central (as of 2026-03-06); tests use SolrJ 9.x against a Solr 10 server. Update `solr-solrj` and Jetty BOM when 10.x is released.

Every part of that is now false:

- **SolrJ 10.x is on Maven Central.** `https://repo1.maven.org/maven2/org/apache/solr/solr-solrj/10.0.0/solr-solrj-10.0.0.pom` returns 200, and `mavenCentral()` is the build's only declared repository.
- **`solr-solrj` is already updated.** #58 bumped it 9.9.0 → 10.0.0 on 2026-03-24, 18 days after the note was written; `gradle/libs.versions.toml` has pinned `solr = "10.0.0"` since.
- **The version skew is the reverse of what's written.** `solr.test.image` defaults to `solr:9.9-slim`, so the standard build exercises a SolrJ 10 *client* against a Solr 9.9 *server*, not a SolrJ 9 client against Solr 10.
- **The Jetty BOM action item is moot.** The Jetty artifacts are declared versionless and managed by Spring Boot's BOM — there is no separate pin to update.

This matters because it reads as an open action item ("update `solr-solrj` ... when 10.x is released") for work that was completed four months ago, and it misdescribes what the test suite actually covers.

## Changes

Restates the bullet as current fact, and notes the client-newer-than-default-server skew since that's the genuinely useful thing for a contributor to know.

Corrected in both places the claim appears:
- `AGENTS.md` (which `CLAUDE.md` symlinks to)
- `dev-docs/DEVELOPMENT.md`

Docs only — no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)