### PR TITLE
docs(security): document single-tenant deployment model (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Running in **HTTP mode** — OAuth2, CORS, and the `HTTP_SECURITY_ENABLED` toggl
 **Using it**
 - [Quick start](docs/site/content/pages/mcp/quick-start.md) · [Client setup](docs/site/content/pages/mcp/clients/) — Claude Desktop, Claude Code, VS Code, Cursor, JetBrains, MCP Inspector
 - [Observability](docs/site/content/pages/mcp/observability.md) — OpenTelemetry traces, metrics, logs
-- Security: [STDIO model](docs/security/stdio.md) · [HTTP model](docs/security/http.md) · OAuth2 setup: [Auth0](docs/security/auth0.md) · [Keycloak](docs/security/keycloak.md)
+- Security: [Deployment model (single-tenant)](docs/security/deployment-model.md) · [STDIO model](docs/security/stdio.md) · [HTTP model](docs/security/http.md) · OAuth2 setup: [Auth0](docs/security/auth0.md) · [Keycloak](docs/security/keycloak.md)
 
 **Developing it**
 - [Development guide](dev-docs/DEVELOPMENT.md) — build, run, test, IDE, native image, SBOM · [Architecture](dev-docs/ARCHITECTURE.md)

--- a/docs/security/deployment-model.md
+++ b/docs/security/deployment-model.md
@@ -1,0 +1,23 @@
+# Deployment Model — Single-Tenant by Design
+
+**The Solr MCP server is single-tenant. It does not support multi-tenancy.**
+
+The intended deployment is one instance per user, configured with that user's
+own Solr credentials. Every action the configured Solr identity is allowed to
+perform — including admin, schema, and collection operations — is by design
+reachable through the MCP tools. The server performs no per-user authorization
+or tenant isolation of its own; to limit what the tools can do, scope the Solr
+identity in Solr (Basic Auth, roles, mTLS, network policy).
+
+In HTTP mode, OAuth2 authenticates *that* a caller is allowed in, but every
+authenticated caller shares the same single Solr identity — it is an access
+gate, not a tenant boundary.
+
+Sharing one instance across multiple users, or otherwise treating it as
+multi-tenant, is unsupported: you are on your own for isolation and any
+resulting exposure. Multi-tenancy may be considered in a future release.
+
+## Related documents
+
+- [STDIO transport security model](./stdio.md)
+- [HTTP transport security model](./http.md)

--- a/docs/security/http.md
+++ b/docs/security/http.md
@@ -171,6 +171,7 @@ exists for browser-based tooling.
 
 ## Related documents
 
+- [Deployment model — single-tenant by design](./deployment-model.md)
 - [STDIO transport security model](./stdio.md)
 - OAuth2 provider setup: [Auth0](./auth0.md) · [Keycloak](./keycloak.md)
 - [GraalVM native image spec](../specs/graalvm-native-image.md)

--- a/docs/security/stdio.md
+++ b/docs/security/stdio.md
@@ -93,6 +93,7 @@ that launched the process. No code changes are required for STDIO security.
 
 ## Related documents
 
+- [Deployment model — single-tenant by design](./deployment-model.md)
 - [HTTP transport security model](./http.md)
 - OAuth2 provider setup (HTTP mode): [Auth0](./auth0.md) · [Keycloak](./keycloak.md)
 - [GraalVM native image spec](../specs/graalvm-native-image.md)


### PR DESCRIPTION
Resolves #169.

Formally documents that the Solr MCP server is **single-tenant** and does not support multi-tenancy: the intended deployment is one instance per user, configured with that user's own Solr credentials, and every action the configured Solr identity is permitted is reachable through the MCP tools by design. Authorization is delegated to Solr, not re-implemented in the MCP layer. Setting this expectation up front avoids "too permissive / insecure for multi-tenant use" reports for behavior that is intentional under this model.

## Changes

- **New `docs/security/deployment-model.md`** — the single authoritative statement of the tenancy model. Concise: states the limitation, that Solr owns authorization, that HTTP-mode OAuth2 is an access gate rather than a tenant boundary, and that sharing one instance across users is unsupported (operator owns the isolation risk). Multi-tenancy noted as possible future work.
- **Pointer links only** (no re-declaration) from the README security list and the STDIO/HTTP transport security docs.

`THREAT_MODEL` is intentionally left untouched — it is handled separately in #160.