### PR TITLE
fix(native): register DefaultMetaProvider reflection hint to unbreak nativeTest

### DIFF
--- a/src/main/java/org/apache/solr/mcp/server/config/SolrNativeHints.java
+++ b/src/main/java/org/apache/solr/mcp/server/config/SolrNativeHints.java
@@ -115,6 +115,13 @@ public class SolrNativeHints {
 				hints.reflection().registerTypeIfPresent(classLoader, className, categories);
 			}
 
+			// Spring AI MCP reflectively instantiates DefaultMetaProvider via its
+			// no-arg constructor in MetaUtils.getMeta() when building resource
+			// specifications. AOT does not generate this hint automatically.
+			hints.reflection().registerTypeIfPresent(classLoader,
+					"org.springaicommunity.mcp.context.DefaultMetaProvider",
+					MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+
 			// Include logback.xml in the native image so logback's early
 			// initialization (before Spring Boot) finds it and applies the
 			// NopStatusListener. Without this, logback falls through to

--- a/src/test/java/org/apache/solr/mcp/server/config/SolrConfigAuthTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/config/SolrConfigAuthTest.java
@@ -28,6 +28,7 @@ import java.util.Base64;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.HttpJdkSolrClient;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,10 @@ import org.springframework.util.ReflectionUtils;
  * encoding.
  */
 @JsonTest
+@DisabledInNativeImage // Reflects into SolrJ's private basicAuthAuthorizationStr field, which is
+// not registered for reflection under GraalVM's closed-world model. The
+// basic-auth
+// wiring logic itself is fully covered by the JVM test run.
 class SolrConfigAuthTest {
 
 	@Autowired

--- a/src/test/java/org/apache/solr/mcp/server/config/SolrConfigAuthTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/config/SolrConfigAuthTest.java
@@ -46,10 +46,10 @@ import org.springframework.util.ReflectionUtils;
  * encoding.
  */
 @JsonTest
-@DisabledInNativeImage // Reflects into SolrJ's private basicAuthAuthorizationStr field, which is
-// not registered for reflection under GraalVM's closed-world model. The
-// basic-auth
+// Reflects into SolrJ's private basicAuthAuthorizationStr field, which is not
+// registered for reflection under GraalVM's closed-world model. The basic-auth
 // wiring logic itself is fully covered by the JVM test run.
+@DisabledInNativeImage
 class SolrConfigAuthTest {
 
 	@Autowired

--- a/src/test/java/org/apache/solr/mcp/server/config/SolrNativeHintsTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/config/SolrNativeHintsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.mcp.server.config;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+/**
+ * Verifies that {@link SolrNativeHints.Registrar} registers the reflection and
+ * resource hints the native image depends on.
+ *
+ * <p>
+ * The hints are otherwise only exercised by {@code nativeTest -Pnative} (a full
+ * GraalVM build), so an accidentally removed registration would surface as a
+ * hard-to-diagnose native-only startup failure. This test pins the
+ * registrations on the plain JVM path where a regression fails in seconds.
+ */
+class SolrNativeHintsTest {
+
+	private final RuntimeHints hints = new RuntimeHints();
+
+	@BeforeEach
+	void registerHints() {
+		new SolrNativeHints.Registrar().registerHints(hints, getClass().getClassLoader());
+	}
+
+	@Test
+	void registersDefaultMetaProviderConstructorHint() {
+		// Spring AI MCP instantiates DefaultMetaProvider reflectively in
+		// MetaUtils.getMeta(); without this hint every Spring context refresh
+		// fails in native image with "Required no-arg constructor not found".
+		assertTrue(RuntimeHintsPredicates.reflection()
+				.onType(TypeReference.of("org.springaicommunity.mcp.context.DefaultMetaProvider"))
+				.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS).test(hints));
+	}
+
+	@Test
+	void registersSolrjResponseTypeHints() {
+		assertTrue(RuntimeHintsPredicates.reflection().onType(QueryResponse.class)
+				.withMemberCategories(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+						MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS)
+				.test(hints));
+	}
+
+	@Test
+	void registersMcpResponseRecordHints() {
+		assertTrue(RuntimeHintsPredicates.reflection()
+				.onType(TypeReference.of("org.apache.solr.mcp.server.search.SearchResponse"))
+				.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS).test(hints));
+	}
+
+	@Test
+	void registersLogbackXmlResourceHint() {
+		// Required so logback's pre-Spring initialization finds logback.xml and
+		// stays silent on stdout (MCP STDIO framing).
+		assertTrue(RuntimeHintsPredicates.resource().forResource("logback.xml").test(hints));
+	}
+}


### PR DESCRIPTION
# Summary

`./gradlew nativeTest -Pnative` fails on every branch and PR (e.g. [PR #159's run](https://github.com/apache/solr-mcp/actions/runs/29925649186): 68 test failures). All failures collapse to a single root cause during `ApplicationContext` refresh:

```
IllegalArgumentException: Required no-arg constructor not found in
  org.springaicommunity.mcp.context.DefaultMetaProvider
    at org.springaicommunity.mcp.MetaUtils.getMeta(MetaUtils.java:63)
    at org.springaicommunity.mcp.provider.resource.SyncStatelessMcpResourceProvider.lambda$getResourceSpecifications$2(...)
...
Caused by: java.lang.NoSuchMethodException:
  org.springaicommunity.mcp.context.DefaultMetaProvider.<init>()
```

The context fails to load 8 times and the remaining ~60 tests cascade-fail on `ApplicationContext failure threshold (1) exceeded`.

# Root cause

Spring AI 1.1.6 introduced a `MetaUtils.getMeta()` call path in the sync resource providers that reflectively invokes the no-arg constructor of `DefaultMetaProvider` when building the `resourceSpecs` bean. Spring AOT does not generate a reflection hint for it, so the constructor is invisible in GraalVM's closed world. Because `resourceSpecs` is part of the real application context (not just tests), the native *server binary* is affected too — currently masked in CI because the docker integration tests fail earlier on an image-tag mismatch (companion PR: https://github.com/apache/solr-mcp/pull/173).

# Changes

1. **`fix(native)`**: register `MemberCategory.INVOKE_DECLARED_CONSTRUCTORS` for `org.springaicommunity.mcp.context.DefaultMetaProvider` in `SolrNativeHints`, alongside the existing SolrJ and MCP response-record hints. `registerTypeIfPresent` keeps it a no-op if a future Spring AI release removes or relocates the class.
2. **`test(config)`**: `@DisabledInNativeImage` on `SolrConfigAuthTest`. It reflects into SolrJ's private `basicAuthAuthorizationStr` field, which is not registered for reflection in the closed world, so its 5 tests fail in nativeTest (they pass on the JVM, which fully covers the basic-auth wiring). This second gap is currently masked by the `DefaultMetaProvider` failure — fixing only that one would leave nativeTest red with these 5.

# Verification (local, GraalVM CE 25 / macOS arm64)

- Before: `nativeTest -Pnative` reproduces CI's failure (every `@SpringBootTest` fails on `DefaultMetaProvider`; with only the hint fix applied, 5 `SolrConfigAuthTest` failures remain).
- After both commits: **`nativeTest -Pnative` → 213 tests successful, 0 failed** (136 skipped: the Mockito/`@DisabledInNativeImage` set).
- `./gradlew spotlessCheck build` passes (JVM path unaffected).
- Additionally verified the pair with https://github.com/apache/solr-mcp/pull/173 end-to-end: `bootBuildImage -Pnative` + `dockerIntegrationTest -Pnative` → the native stdio image passes the MCP protocol suite (39 tests) and smoke tests. The http leg as well: `dockerIntegrationTest -Pnative -Pprofile=http` → `DockerImageHttpIntegrationTest` (6 tests) passes against `solr-mcp:1.0.0-SNAPSHOT-native-http`.

# Merge order

This PR and https://github.com/apache/solr-mcp/pull/173 are independent to review but jointly required for a green `native.yml`: this one fixes the `nativeTest` job; the companion fixes the image tag the docker jobs resolve. Suggest merging this one first (its docker jobs will still be red on the pre-existing tag mismatch), then the companion turns the matrix fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)