### PR TITLE
fix(test): restore docker image tag suffix for native integration tests

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -42,6 +42,11 @@ on:
             - '.github/workflows/native.yml'
             - 'src/main/java/**/*NativeHints*.java'
             - 'src/main/resources/META-INF/native-image/**'
+            # The Docker integration tests are the native-image validation suite,
+            # so changes to them (or the image-name helper they rely on) must
+            # re-trigger this workflow.
+            - 'src/test/java/**/containerization/**'
+            - 'src/test/java/**/BuildInfoReader.java'
 
 jobs:
     native-test:

--- a/src/test/java/org/apache/solr/mcp/server/BuildInfoReader.java
+++ b/src/test/java/org/apache/solr/mcp/server/BuildInfoReader.java
@@ -87,12 +87,23 @@ public class BuildInfoReader {
 	}
 
 	/**
-	 * Gets the Docker image name in the format "artifact:version".
+	 * Gets the Docker image name in the format {@code artifact:version<suffix>}.
 	 *
-	 * @return Docker image name (e.g., "solr-mcp:1.0.0-SNAPSHOT")
+	 * <p>
+	 * The optional {@code solr.mcp.docker.image.tag.suffix} system property is
+	 * appended to the tag so that the native {@code dockerIntegrationTest} runs
+	 * target the per-profile Paketo images ({@code -native-stdio} /
+	 * {@code -native-http}). For the JVM (Jib) path the property is unset and
+	 * defaults to an empty string, yielding the plain {@code artifact:version} tag.
+	 * Appending here (rather than at every call site) keeps the suffix applied
+	 * exactly once.
+	 *
+	 * @return Docker image name (e.g., "solr-mcp:1.0.0-SNAPSHOT" or
+	 *         "solr-mcp:1.0.0-SNAPSHOT-native-stdio")
 	 */
 	public static String getDockerImageName() {
-		return String.format("%s:%s", getArtifact(), getVersion());
+		String suffix = System.getProperty("solr.mcp.docker.image.tag.suffix", "");
+		return String.format("%s:%s%s", getArtifact(), getVersion(), suffix);
 	}
 
 	/**

--- a/src/test/java/org/apache/solr/mcp/server/BuildInfoReaderTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/BuildInfoReaderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.mcp.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link BuildInfoReader}'s Docker image name resolution.
+ *
+ * <p>
+ * The {@code solr.mcp.docker.image.tag.suffix} handling is otherwise exercised
+ * only by {@code dockerIntegrationTest}, which regular CI never runs — that gap
+ * is how PR #139 could silently drop the suffix and break the native image
+ * matrix. These tests pin the contract in the default {@code test} task.
+ */
+class BuildInfoReaderTest {
+
+	private static final String SUFFIX_PROPERTY = "solr.mcp.docker.image.tag.suffix";
+
+	private String previousSuffix;
+
+	@BeforeEach
+	void captureSuffixProperty() {
+		previousSuffix = System.getProperty(SUFFIX_PROPERTY);
+		System.clearProperty(SUFFIX_PROPERTY);
+	}
+
+	@AfterEach
+	void restoreSuffixProperty() {
+		if (previousSuffix == null) {
+			System.clearProperty(SUFFIX_PROPERTY);
+		} else {
+			System.setProperty(SUFFIX_PROPERTY, previousSuffix);
+		}
+	}
+
+	@Test
+	void plainImageNameWhenSuffixUnset() {
+		assertEquals(BuildInfoReader.getArtifact() + ":" + BuildInfoReader.getVersion(),
+				BuildInfoReader.getDockerImageName());
+	}
+
+	@Test
+	void appendsSuffixPropertyToImageName() {
+		System.setProperty(SUFFIX_PROPERTY, "-native-stdio");
+		assertEquals(BuildInfoReader.getArtifact() + ":" + BuildInfoReader.getVersion() + "-native-stdio",
+				BuildInfoReader.getDockerImageName());
+	}
+}

--- a/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageMcpClientStdioIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageMcpClientStdioIntegrationTest.java
@@ -43,9 +43,10 @@ import org.testcontainers.utility.DockerImageName;
  * lines and {@code initialize()} will fail.
  *
  * <p>
- * Image under test: {@link BuildInfoReader#getDockerImageName()} plus the
- * {@code solr.mcp.docker.image.tag.suffix} system property (set to
- * {@code -native} for {@code dockerIntegrationTest -Pnative}, empty otherwise).
+ * Image under test: {@link BuildInfoReader#getDockerImageName()}, which appends
+ * the {@code solr.mcp.docker.image.tag.suffix} system property
+ * ({@code -native-stdio} / {@code -native-http} under
+ * {@code dockerIntegrationTest -Pnative}, empty on the JVM/Jib path).
  */
 @Tag("docker-integration")
 @Testcontainers(disabledWithoutDocker = true)


### PR DESCRIPTION
# Summary

The two `native Docker image + integration` jobs in `native.yml` fail on every branch and PR (e.g. [PR #159's run](https://github.com/apache/solr-mcp/actions/runs/29925649186)) with:

```
ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=solr-mcp:1.0.0-SNAPSHOT, ...)
```

The Paketo native build tags its image `solr-mcp:<version>-native-stdio` / `-native-http`, but all three Docker integration tests resolve the plain `solr-mcp:<version>` tag, which the native path never produces. The MCP stdio protocol test's `docker run` subprocess exits immediately on the missing image, surfacing as a 20s `initialize()` timeout instead.

# Root cause

PR #139 removed the caller-side `+ System.getProperty("solr.mcp.docker.image.tag.suffix")` concatenation from the three test classes on the premise that `BuildInfoReader.getDockerImageName()` "already appends the same system property internally" — but it never did (it was just `String.format("%s:%s", artifact, version)`). The suffix stopped being applied at all, even though `build.gradle.kts` still sets `solr.mcp.docker.image.tag.suffix` for `dockerIntegrationTest -Pnative` and the test Javadoc still documents it as applied.

# Changes

- `BuildInfoReader.getDockerImageName()` now appends the `solr.mcp.docker.image.tag.suffix` system property (default `""`), so the suffix is applied exactly once, matching #139's documented intent. The JVM (Jib) path is unchanged: the property is unset there, so the tag stays `solr-mcp:<version>`.
- Add the containerization tests and `BuildInfoReader` to `native.yml`'s trigger paths so future changes to the native validation suite re-run the native matrix.

# Verification (local, macOS arm64)

- `./gradlew spotlessCheck build` passes (unit + integration tests; the JVM path resolves the same tag as before).
- End-to-end with companion PR https://github.com/apache/solr-mcp/pull/172 applied: `bootBuildImage -Pnative` + `dockerIntegrationTest -Pnative` → tests resolve `solr-mcp:1.0.0-SNAPSHOT-native-stdio` and pass: `DockerImageMcpClientStdioIntegrationTest` (39 tests, full MCP JSON-RPC workflow) and `DockerImageStdioIntegrationTest` (4 tests). The http leg as well: `dockerIntegrationTest -Pnative -Pprofile=http` → `DockerImageHttpIntegrationTest` (6 tests) passes against `solr-mcp:1.0.0-SNAPSHOT-native-http`.

# Merge order

This fixes the *image resolution* failure. With the tag fixed, the docker tests reach the actual native binary — which then needs the `DefaultMetaProvider` reflection hint from companion PR https://github.com/apache/solr-mcp/pull/172 (the `resourceSpecs` bean is part of the real application context). Suggest merging the companion first, then this PR turns the native matrix fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
