### PR TITLE
test: remove brittle assertions and a null image default

### DIFF
--- a/src/test/java/org/apache/solr/mcp/server/McpClientIntegrationTestBase.java
+++ b/src/test/java/org/apache/solr/mcp/server/McpClientIntegrationTestBase.java
@@ -821,9 +821,12 @@ public abstract class McpClientIntegrationTestBase {
 
 	protected static void assertNotError(CallToolResult result) {
 		if (Boolean.TRUE.equals(result.isError())) {
-			String errorText = result.content().isEmpty()
-					? "unknown error"
-					: ((TextContent) result.content().getFirst()).text();
+			// Do not cast blindly: a non-text error payload would raise
+			// ClassCastException here and hide the actual failure message.
+			String errorText = result.content().isEmpty() ? "unknown error" : switch (result.content().getFirst()) {
+				case TextContent text -> text.text();
+				case Object other -> "non-text error content: " + other;
+			};
 			fail("MCP tool call returned error: " + errorText);
 		}
 	}

--- a/src/test/java/org/apache/solr/mcp/server/SampleClient.java
+++ b/src/test/java/org/apache/solr/mcp/server/SampleClient.java
@@ -152,13 +152,16 @@ public class SampleClient {
 			assertNotNull(toolsList, "Tools list should not be null");
 			assertNotNull(toolsList.tools(), "Tools collection should not be null");
 
-			// Validate expected tool count based on MCP server implementation
-			assertEquals(8, toolsList.tools().size(), "Expected 8 tools to be available");
-
-			// Define expected tools based on the log output
+			// Every tool the server is expected to expose. Asserted as a lower
+			// bound plus per-name checks so adding a tool does not break this
+			// client - an exact count went stale as soon as create-collection,
+			// add-fields and add-field-types were added.
 			Set<String> expectedToolNames = Set.of("index-json-documents", "index-csv-documents",
 					"get-collection-stats", "search", "list-collections", "check-health", "index-xml-documents",
-					"get-schema");
+					"get-schema", "create-collection", "add-fields", "add-field-types");
+
+			assertTrue(toolsList.tools().size() >= expectedToolNames.size(),
+					"Expected at least " + expectedToolNames.size() + " tools, got " + toolsList.tools().size());
 
 			// Validate each expected tool is present
 			List<String> actualToolNames = toolsList.tools().stream().map(Tool::name).toList();

--- a/src/test/java/org/apache/solr/mcp/server/collection/CollectionServiceIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/collection/CollectionServiceIntegrationTest.java
@@ -233,8 +233,10 @@ class CollectionServiceIntegrationTest {
 		HandlerInfo select = handlerStats.selectHandler();
 		assertNotNull(select);
 		assertTrue(select.requests() > 0, "Select handler requests should be positive after queries");
-		assertNull(select.errors());
-		assertNull(select.timeouts());
+		// Solr may omit these counters entirely or report an explicit 0 - both mean
+		// "nothing went wrong". Requiring null made the test depend on which.
+		assertTrue(select.errors() == null || select.errors() == 0L, "Select handler should report no errors");
+		assertTrue(select.timeouts() == null || select.timeouts() == 0L, "Select handler should report no timeouts");
 
 		// Update handler: indexing 50 docs should have driven request counts > 0
 		HandlerInfo update = handlerStats.updateHandler();

--- a/src/test/java/org/apache/solr/mcp/server/config/SolrConfigIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/config/SolrConfigIntegrationTest.java
@@ -33,7 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Import(TestcontainersConfiguration.class)
 @Tag("integration")
 @Testcontainers(disabledWithoutDocker = true)
-class SolrConfigTest {
+class SolrConfigIntegrationTest {
 
 	@Autowired
 	private SolrClient solrClient;

--- a/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageHttpIntegrationTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/containerization/DockerImageHttpIntegrationTest.java
@@ -95,7 +95,9 @@ class DockerImageHttpIntegrationTest {
 
 	// Docker image name and tag from build-info.properties
 	private static final String DOCKER_IMAGE = BuildInfoReader.getDockerImageName();
-	private static final String SOLR_IMAGE = System.getProperty("solr.test.image");
+	// Same default as DockerImageMcpClientStdioIntegrationTest - without it,
+	// DockerImageName.parse receives null whenever the property is unset.
+	private static final String SOLR_IMAGE = System.getProperty("solr.test.image", "solr:9.9-slim");
 	private static final int HTTP_PORT = 8080;
 
 	// Network for container communication


### PR DESCRIPTION
Verified findings from a CodeRabbit review. Test-only — no production code is touched.

- `DockerImageHttpIntegrationTest` read `solr.test.image` with **no default**, so `DockerImageName.parse` received `null` whenever the property was unset. Now uses the same default as `DockerImageMcpClientStdioIntegrationTest`.
- `SampleClient` asserted an exact tool count of **8**; the server exposes **11**, and the list went stale as soon as `create-collection`, `add-fields` and `add-field-types` were added. Now a lower bound plus per-name presence, so adding a tool will not break it.
- `CollectionServiceIntegrationTest` required `select.errors()` and `select.timeouts()` to be `null`. Solr may omit these counters **or** report an explicit `0`, and both mean nothing went wrong — the test depended on which.
- `McpClientIntegrationTestBase.assertNotError` cast the first content item to `TextContent`, so a non-text error payload raised `ClassCastException` and **hid the actual failure message**.
- Renamed `SolrConfigTest` → `SolrConfigIntegrationTest`: it is `@Tag("integration")` and starts Testcontainers, contradicting the project's `*Test` = unit / `*IntegrationTest` = integration convention documented in `AGENTS.md`.

## Verification

`./gradlew build` on JDK 25, against real Solr via Testcontainers: **BUILD SUCCESSFUL** — 352 tests, 0 failures, 0 errors, 7 skipped. No spotless drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
