### PR TITLE
docs: correct claims that do not match the code

### DIFF
--- a/.run/SolrMcpServerHttp.run.xml
+++ b/.run/SolrMcpServerHttp.run.xml
@@ -3,7 +3,9 @@
                    factoryName="Spring Boot">
         <option name="ACTIVE_PROFILES" value="http"/>
         <envs>
-            <env name="OAUTH2_ISSUER_URI" value="https://dev-qa6ay6y8fhsk7m7l.us.auth0.com/"/>
+            <!-- Placeholder: point this at your own issuer before running.
+                 Do not commit a contributor-specific tenant URL. -->
+            <env name="OAUTH2_ISSUER_URI" value="https://YOUR_TENANT.us.auth0.com/"/>
         </envs>
         <module name="solr-mcp.main"/>
         <option name="SPRING_BOOT_MAIN_CLASS" value="org.apache.solr.mcp.server.Main"/>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Four service classes expose MCP tools via `@McpTool` annotations:
 
 - **SearchService** (`search/`) - Full-text search with filtering, faceting, sorting, pagination
 - **IndexingService** (`indexing/`) - Document indexing supporting JSON, CSV, XML formats
-- **CollectionService** (`metadata/`) - List collections, get stats, health checks
+- **CollectionService** (`collection/`) - List collections, get stats, health checks
 - **SchemaService** (`schema/`) - Schema introspection and additive modification (add-fields, add-field-types)
 
 ### Document Creators (Strategy Pattern)

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ src/main/java/org/apache/solr/mcp/server/
 │       ├── SolrDocumentCreator.java        # Common interface for document creators
 │       ├── FieldNameSanitizer.java         # Field name sanitization utility
 │       └── DocumentProcessingException.java # Indexing exceptions
-└── metadata/                           # Collection management functionality
+└── collection/                           # Collection management functionality
     ├── CollectionService.java         # MCP tools for collection operations
     ├── SchemaService.java             # MCP tool for schema retrieval
     ├── CollectionUtils.java           # Collection utility methods
@@ -61,11 +61,12 @@ Strategy pattern implementation for parsing different document formats:
 
 ### DTOs
 
-Plain Java classes (POJOs) used as data transfer objects:
+Java `record` types used as data transfer objects:
 
-- No Lombok dependency; simple, explicit types
+- No Lombok dependency; the record declaration is the whole definition
 - Designed for straightforward serialization/deserialization
-- Favor clarity; immutability can be introduced where it adds value
+- Records are immutable by construction, so the response types handed to
+  MCP clients cannot be mutated after they are built
 
 ## Design Decisions
 
@@ -132,24 +133,38 @@ The document creator pattern allows for:
 ### Test Structure
 ```
 src/test/java/org/apache/solr/mcp/server/
+├── MainTest.java                      # Application bootstrap
 ├── McpToolRegistrationTest.java       # MCP tool registration tests
+├── McpClientIntegrationTest.java      # MCP workflow over the in-process client
+├── McpClientStdioIntegrationTest.java # MCP workflow against `java -jar` over STDIO
 ├── BuildInfoReader.java               # Test utility for build metadata
 ├── SampleClient.java                  # Example MCP client
 ├── search/
-│   ├── SearchServiceTest.java         # Unit tests
-│   └── SearchServiceDirectTest.java   # Integration tests
+│   ├── SearchServiceTest.java             # Unit tests
+│   └── SearchServiceIntegrationTest.java  # Testcontainers
 ├── indexing/
 │   ├── IndexingServiceTest.java
-│   ├── IndexingServiceDirectTest.java
+│   ├── IndexingServiceIntegrationTest.java
 │   ├── CsvIndexingTest.java
 │   └── XmlIndexingTest.java
-├── metadata/
+├── collection/
 │   ├── CollectionServiceTest.java
+│   ├── CollectionUtilsTest.java
 │   ├── CollectionServiceIntegrationTest.java
+│   └── ConferenceEndToEndIntegrationTest.java
+├── schema/
 │   ├── SchemaServiceTest.java
 │   └── SchemaServiceIntegrationTest.java
-└── containerization/
+├── config/
+│   ├── JsonResponseParserTest.java
+│   ├── SolrConfigUrlNormalizationTest.java
+│   └── SolrConfigIntegrationTest.java
+├── observability/
+│   ├── DistributedTracingTest.java
+│   └── OtlpExportIntegrationTest.java
+└── containerization/                  # @Tag("docker-integration") only
     ├── DockerImageStdioIntegrationTest.java
+    ├── DockerImageMcpClientStdioIntegrationTest.java
     └── DockerImageHttpIntegrationTest.java
 ```
 
@@ -179,9 +194,9 @@ All dependencies are managed via Gradle version catalogs in `gradle/libs.version
 ### Potential Enhancements
 
 1. **Authentication & Authorization**
-   - OAuth2 support for HTTP mode
-   - Token-based authentication
    - Role-based access control
+   (OAuth2 resource-server support and bearer-token authentication for HTTP
+   mode are already implemented — see `security/HttpSecurityConfiguration`.)
 
 2. **Additional Tools**
    - Bulk operations

--- a/dev-docs/ATR_TESTING_GUIDE.md
+++ b/dev-docs/ATR_TESTING_GUIDE.md
@@ -127,8 +127,8 @@ cd build/distributions
 sha512sum solr-mcp-0.0.1-test-rc1-src.tar.gz > solr-mcp-0.0.1-test-rc1-src.tar.gz.sha512
 sha256sum solr-mcp-0.0.1-test-rc1-src.tar.gz > solr-mcp-0.0.1-test-rc1-src.tar.gz.sha256
 
-# 4. Verify artifacts
-ls -lh build/distributions/
+# 4. Verify artifacts (still inside build/distributions from the cd above)
+ls -lh
 sha512sum -c solr-mcp-0.0.1-test-rc1-src.tar.gz.sha512
 ```
 
@@ -332,7 +332,10 @@ jobs:
 
         steps:
             -   name: Request PMC verification
-                uses: trstringer/manual-approval@v1
+                # ASF's Actions allow-list matches third-party actions by exact
+                # commit SHA, not by tag - a mutable @v1 ref makes the workflow
+                # fail at startup. Pin the reviewed SHA before using this.
+                uses: trstringer/manual-approval@<reviewed-commit-sha> # v1
                 with:
                     approvers: apache-pmc-members  # Replace with actual PMC GitHub team
                     minimum-approvals: 1

--- a/dev-docs/DEPLOYMENT.md
+++ b/dev-docs/DEPLOYMENT.md
@@ -173,7 +173,7 @@ docker run -i --rm \
 ### Workflows
 
 - `.github/workflows/build-and-publish.yml` — Build, test, and publish Docker images
-- `.github/workflows/publish-mcp.yml` — Publish to the Model Context Protocol Registry on version tags
+- `.github/workflows/release-publish.yml` — the `publish-mcp-registry` job publishes to the Model Context Protocol Registry after a release vote passes
 
 ### Docker image publishing
 
@@ -194,7 +194,7 @@ To publish images, use Jib from your local machine or set up your own workflow:
 
 ### MCP Registry Publishing
 
-`.github/workflows/publish-mcp.yml` publishes to the Model Context Protocol Registry.
+The `publish-mcp-registry` job in `.github/workflows/release-publish.yml` publishes to the Model Context Protocol Registry.
 
 **Triggers:**
 - Version tags (e.g., `v0.1.0`)
@@ -412,8 +412,12 @@ The server exposes Spring Boot Actuator endpoints:
 # Health check
 curl http://localhost:8080/actuator/health
 
-# Build info
-curl http://localhost:8080/actuator/info
+# Build info. Only /actuator/health is anonymous; every other actuator
+# endpoint requires authentication when HTTP security is enabled (the default),
+# so pass a bearer token:
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/actuator/info
+
+# ...or run with HTTP_SECURITY_ENABLED=false for a local unsecured setup.
 ```
 
 ### Docker Health Check

--- a/dev-docs/DEVELOPMENT.md
+++ b/dev-docs/DEVELOPMENT.md
@@ -102,8 +102,9 @@ docker compose up -d
 ```
 
 This starts a Solr instance in SolrCloud mode with ZooKeeper and creates two sample collections:
-- `books` - Collection with sample book data
-- `films` - Collection with sample film data
+- `books` - Created empty. The books.csv download and post are commented out in
+  `init-solr.sh`, so use it as a scratch collection or uncomment those lines.
+- `films` - Collection populated with Solr's sample film data
 
 ### Run the Server
 
@@ -438,7 +439,7 @@ Standard debugging works normally:
        description = "What this tool does"
    )
    public String myTool(
-       @McpToolParameter(description = "Parameter description")
+       @McpToolParam(description = "Parameter description")
        String param
    ) {
        // Implementation
@@ -449,8 +450,8 @@ Standard debugging works normally:
 
 ### Adding a New Document Format
 
-1. Create a new class implementing `IndexingDocumentCreator`
-2. Register in `SolrDocumentCreator` factory
+1. Create a new class implementing `SolrDocumentCreator` (the format interface)
+2. Register it with the `IndexingDocumentCreator` orchestrator
 3. Add tests
 4. Update documentation
 
@@ -491,7 +492,7 @@ Analyze with Java Mission Control.
 The project uses GitHub Actions for CI/CD. See:
 
 - `.github/workflows/build-and-publish.yml` - Build, test, and publish Docker images
-- `.github/workflows/publish-mcp.yml` - Publish to the MCP Registry on version tags
+- `.github/workflows/release-publish.yml` - the `publish-mcp-registry` job publishes to the MCP Registry after a release vote passes
 
 Local CI simulation:
 

--- a/dev-docs/DOCKER_PUBLISHING.md
+++ b/dev-docs/DOCKER_PUBLISHING.md
@@ -98,10 +98,12 @@ Trigger the release publish workflow:
 # Build to local Docker daemon
 ./gradlew jibDockerBuild
 
-# Build and push to registry
-./gradlew jib -Djib.to.image=myregistry/solr-mcp:my-tag \
-              -Djib.to.auth.username=USERNAME \
-              -Djib.to.auth.password=TOKEN
+# Build and push to registry.
+# Pass credentials through the environment, not -Djib.to.auth.*: command-line
+# arguments are visible to any process that can run `ps` on the machine.
+export JIB_TO_AUTH_USERNAME=USERNAME
+export JIB_TO_AUTH_PASSWORD=TOKEN
+./gradlew jib -Djib.to.image=myregistry/solr-mcp:my-tag
 ```
 
 ### Multi-platform Build

--- a/dev-docs/TROUBLESHOOTING.md
+++ b/dev-docs/TROUBLESHOOTING.md
@@ -255,8 +255,12 @@ The following files had format violations:
 
 **Solution:**
 ```bash
-# Clean Gradle cache
+# Remove build outputs and bypass the build cache for this run
+# (this does NOT purge the cache itself)
 ./gradlew clean --no-build-cache
+
+# Actually purge the Gradle build cache
+rm -rf ~/.gradle/caches/build-cache-1
 
 # Nuclear option: delete .gradle directory
 rm -rf .gradle
@@ -404,8 +408,10 @@ If you're still having issues:
 ### Server Logs
 
 ```bash
-# STDIO mode - logs to stderr
-./gradlew bootRun 2>&1 | tee server.log
+# STDIO mode - logs go to stderr; capture stderr ONLY.
+# Do not use 2>&1: that merges diagnostics into stdout, which carries the
+# MCP JSON-RPC stream and must stay clean.
+./gradlew bootRun 2> server.log
 
 # HTTP mode - Spring Boot logging
 PROFILES=http ./gradlew bootRun

--- a/dev-docs/WORKFLOWS.md
+++ b/dev-docs/WORKFLOWS.md
@@ -62,8 +62,9 @@ This guide explains when and how to use each GitHub Actions workflow in the proj
 #### When to Use
 
 - ✅ Automatic on every commit to `main`
-- ✅ Automatic on pull requests (build + test only)
 - ✅ When you merge a PR and want development images published
+
+(Pull requests are built by `ci.yml`, not by this workflow.)
 
 #### When NOT to Use
 
@@ -77,10 +78,12 @@ on:
   push:
     branches: [main]
     tags: ['v*']  # ⚠️ Avoid using tags; prefer release-publish.yml
-  pull_request:
-    branches: [main]
   workflow_dispatch:  # Manual trigger
 ```
+
+There is deliberately **no `pull_request` trigger**: this workflow publishes
+images, and pull requests must not be able to push to a registry. PR builds are
+covered by `ci.yml`.
 
 #### What It Does
 
@@ -162,7 +165,10 @@ on:
 
 1. **Validates** release tag exists (`v1.0.0-rc1`)
 2. **Builds** the project from approved RC tag
-3. **Signs** artifacts (placeholder for future automation)
+3. **Signs** artifacts — placeholder only; this step logs a message and does
+   not produce or verify a signature. Publication below is **not** gated on a
+   verified signature, so the Release Manager must still sign manually per the
+   ATR guidance.
 4. **Publishes Docker images** to:
     - Docker Hub: `apache/solr-mcp:1.0.0`, `apache/solr-mcp:1.0`, `apache/solr-mcp:1`, `apache/solr-mcp:latest`
     - GitHub Container Registry: `ghcr.io/apache/solr-mcp:1.0.0`, `latest`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -72,15 +72,15 @@ Anthropic puts it, *"tool descriptions occupy more context window
 space"*, and at scale agents *"need to process hundreds of thousands of
 tokens before reading a request."*[code-execution]
 
-For this server (27 tools across search, indexing, schema, and
+For this server (11 tools across search, indexing, schema, and
 collections), the upfront overhead is a few thousand tokens — real but
 bounded.
 
 Two factors close the gap at runtime:
 
-- **Typed, compact returns.** Every tool returns the same typed record
-  (e.g. `SearchResponse`, `SolrHealthStatus`), not raw Solr JSON the
-  model must reparse. Over a multi-turn agent run, leaner tool output
+- **Typed, compact returns.** Every tool returns its own purpose-built
+  typed record (`SearchResponse`, `SolrHealthStatus`, `IndexStats`, …),
+  not raw Solr JSON the model must reparse. Over a multi-turn agent run, leaner tool output
   offsets the upfront schema cost.
 - **Code execution with MCP.** Anthropic's pattern of discovering tool
   definitions on demand inside a code-execution loop cut a reference

--- a/docs/security/stdio.md
+++ b/docs/security/stdio.md
@@ -15,8 +15,8 @@ that launched the process. No code changes are required for STDIO security.
 | Property | Where it's set | Why it's safe |
 |---|---|---|
 | No network listener | `application-stdio.properties` → `spring.main.web-application-type=none` | No socket exists for a remote attacker to reach |
-| Communication is stdin/stdout only | MCP framing per spec | Only the parent process (e.g. Claude Desktop) can write to `stdin` |
-| Trust boundary = OS process owner | Launcher runs the binary | Same model as any local CLI; OS user permissions are the auth |
+| Communication is stdin/stdout only | MCP framing per spec | No socket to reach; input arrives over an inherited file descriptor |
+| Trust boundary = OS process owner | Launcher runs the binary | Same model as any local CLI; OS user permissions are the auth. Note the boundary is **any process that can reach the server's stdin**, not only the direct parent — a descriptor can be inherited or passed on, so isolate by OS user rather than assuming a single writer |
 | Spring Security autoconfig disabled | `application-stdio.properties` excludes `SecurityAutoConfiguration` and `ManagementWebSecurityAutoConfiguration` | Belt-and-suspenders; the filter chain has nothing to do without a servlet container |
 | `stdout` is reserved for JSON-RPC | `logback.xml` + empty `logging.pattern.console` (see [Logging Architecture in CLAUDE.md](../../CLAUDE.md#logging-architecture)) | Prevents log lines from being mis-parsed as MCP frames |
 

--- a/init-solr.sh
+++ b/init-solr.sh
@@ -92,18 +92,23 @@ until curl -s "http://localhost:8983/solr/admin/collections?action=LIST" | grep 
   sleep 2
 done
 
+# Both fields go in a single "add-field" array. Repeating the key instead
+# would leave duplicate JSON members, and the second silently wins - so the
+# "name" field was never actually created.
 curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "add-field": {
-    "name":"name",
-    "type":"text_general",
-    "multiValued":false,
-    "stored":true
-  },
-  "add-field": {
-    "name":"initial_release_date",
-    "type":"pdate",
-    "stored":true
-  }
+  "add-field": [
+    {
+      "name":"name",
+      "type":"text_general",
+      "multiValued":false,
+      "stored":true
+    },
+    {
+      "name":"initial_release_date",
+      "type":"pdate",
+      "stored":true
+    }
+  ]
 }' http://localhost:8983/solr/films/schema
 
 ## Post the books.csv data

--- a/mydata/devnexus-2026.json
+++ b/mydata/devnexus-2026.json
@@ -9,7 +9,7 @@
     "day": "Day 0",
     "date": "2026-03-04",
     "start_time": "09:00",
-    "start_datetime": "2026-03-04T09:00:00Z",
+    "start_datetime": "2026-03-04T14:00:00Z",
     "session_type": "Workshop",
     "tags": ["event-driven", "event-streaming", "architecture", "workshop"]
   },
@@ -23,7 +23,7 @@
     "day": "Day 0",
     "date": "2026-03-04",
     "start_time": "09:00",
-    "start_datetime": "2026-03-04T09:00:00Z",
+    "start_datetime": "2026-03-04T14:00:00Z",
     "session_type": "Workshop",
     "tags": ["software-engineering", "ai", "practices", "workshop"]
   },
@@ -37,7 +37,7 @@
     "day": "Day 0",
     "date": "2026-03-04",
     "start_time": "09:00",
-    "start_datetime": "2026-03-04T09:00:00Z",
+    "start_datetime": "2026-03-04T14:00:00Z",
     "session_type": "Workshop",
     "tags": ["spring-ai", "mcp", "java", "amazon-bedrock", "agents", "workshop"]
   },
@@ -51,7 +51,7 @@
     "day": "Day 0",
     "date": "2026-03-04",
     "start_time": "13:00",
-    "start_datetime": "2026-03-04T13:00:00Z",
+    "start_datetime": "2026-03-04T18:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "patterns", "predictive-ai"]
   },
@@ -65,7 +65,7 @@
     "day": "Day 0",
     "date": "2026-03-04",
     "start_time": "13:00",
-    "start_datetime": "2026-03-04T13:00:00Z",
+    "start_datetime": "2026-03-04T18:00:00Z",
     "session_type": "Talk",
     "tags": ["java", "java-25", "language-evolution", "jvm"]
   },
@@ -79,7 +79,7 @@
     "day": "Day 0",
     "date": "2026-03-04",
     "start_time": "13:00",
-    "start_datetime": "2026-03-04T13:00:00Z",
+    "start_datetime": "2026-03-04T18:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "modernization", "generative-ai"]
   },
@@ -93,7 +93,7 @@
     "day": "Day 0",
     "date": "2026-03-04",
     "start_time": "18:15",
-    "start_datetime": "2026-03-04T18:15:00Z",
+    "start_datetime": "2026-03-04T23:15:00Z",
     "session_type": "Social",
     "tags": ["networking", "social"]
   },
@@ -107,7 +107,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "09:00",
-    "start_datetime": "2026-03-05T09:00:00Z",
+    "start_datetime": "2026-03-05T14:00:00Z",
     "session_type": "Keynote",
     "tags": ["keynote", "java", "ai", "enterprise"]
   },
@@ -121,7 +121,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "design-patterns", "multi-agent"]
   },
@@ -135,7 +135,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "java", "practical"]
   },
@@ -149,7 +149,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["architecture", "data-warehouse", "open-source", "data-lakes", "cloud"]
   },
@@ -163,7 +163,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["java", "java-26", "language-evolution", "jvm"]
   },
@@ -177,7 +177,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-boot", "spring-boot-4", "frameworks"]
   },
@@ -191,7 +191,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "mcp", "agents", "generative-ai", "tools"]
   },
@@ -205,7 +205,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "09:00",
-    "start_datetime": "2026-03-05T09:00:00Z",
+    "start_datetime": "2026-03-05T14:00:00Z",
     "session_type": "Community",
     "tags": ["mentorship", "community", "career"]
   },
@@ -219,7 +219,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["refactoring", "practices", "code-quality"]
   },
@@ -233,7 +233,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["spring", "java", "ai", "enterprise", "frameworks"]
   },
@@ -247,7 +247,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["java", "migration", "security", "compatibility"]
   },
@@ -261,7 +261,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["leadership", "career", "education", "engineering-culture"]
   },
@@ -275,7 +275,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "10:00",
-    "start_datetime": "2026-03-05T10:00:00Z",
+    "start_datetime": "2026-03-05T15:00:00Z",
     "session_type": "Talk",
     "tags": ["mcp", "automation", "tools", "productivity"]
   },
@@ -289,7 +289,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "java", "tools", "code-platform"]
   },
@@ -303,7 +303,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["mcp", "ai", "practical", "architecture"]
   },
@@ -317,7 +317,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["java", "testing", "junit", "junit-6"]
   },
@@ -331,7 +331,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-data", "frameworks", "data-access"]
   },
@@ -345,7 +345,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "java", "tools", "generative-ai", "productivity"]
   },
@@ -359,7 +359,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["lean", "practices", "software-development", "agile"]
   },
@@ -373,7 +373,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-cloud", "api", "api-versioning", "gateway", "enterprise"]
   },
@@ -387,7 +387,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-security", "security"]
   },
@@ -401,7 +401,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["architecture", "leadership", "software-development"]
   },
@@ -415,7 +415,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "11:20",
-    "start_datetime": "2026-03-05T11:20:00Z",
+    "start_datetime": "2026-03-05T16:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "ide", "productivity", "tools"]
   },
@@ -429,7 +429,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "software-engineering", "practices", "tools"]
   },
@@ -443,7 +443,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "practical", "critique"]
   },
@@ -457,7 +457,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["java", "cloud", "serverless", "native", "crac", "performance", "architecture"]
   },
@@ -471,7 +471,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["java", "performance", "jvm", "latency"]
   },
@@ -485,7 +485,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "java", "enterprise", "benchmarks", "spring"]
   },
@@ -499,7 +499,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-ai", "mcp", "agents", "generative-ai"]
   },
@@ -513,7 +513,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["git", "practices", "tools", "version-control"]
   },
@@ -527,7 +527,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "tanzu", "ai", "enterprise", "cloud-native"]
   },
@@ -541,7 +541,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["llm", "ai", "security", "reliability", "trust"]
   },
@@ -555,7 +555,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "13:20",
-    "start_datetime": "2026-03-05T13:20:00Z",
+    "start_datetime": "2026-03-05T18:20:00Z",
     "session_type": "Talk",
     "tags": ["leadership", "career", "management"]
   },
@@ -569,7 +569,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["ai", "embabel", "tools", "agents"]
   },
@@ -583,7 +583,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["mcp", "ai", "agents", "protocol"]
   },
@@ -597,7 +597,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["architecture", "modular-monolith", "microservices"]
   },
@@ -611,7 +611,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["java", "kubernetes", "performance", "ai", "jvm"]
   },
@@ -625,7 +625,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["java", "graphs", "ai", "frameworks", "neo4j"]
   },
@@ -639,7 +639,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["mcp", "ai", "java", "modernization", "agents", "generative-ai"]
   },
@@ -653,7 +653,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["refactoring", "intellij", "practices", "code-quality", "ide"]
   },
@@ -667,7 +667,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-ai", "agents", "tanzu", "ai"]
   },
@@ -681,7 +681,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["mcp", "llm", "data-streaming", "kafka", "security"]
   },
@@ -695,7 +695,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["leadership", "management", "one-on-one", "career"]
   },
@@ -709,7 +709,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "14:50",
-    "start_datetime": "2026-03-05T14:50:00Z",
+    "start_datetime": "2026-03-05T19:50:00Z",
     "session_type": "Talk",
     "tags": ["soft-skills", "career", "communication"]
   },
@@ -723,7 +723,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "memory", "tools"]
   },
@@ -737,7 +737,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["ai", "multi-agent", "agents", "practical"]
   },
@@ -751,7 +751,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["java", "cloud-native", "modernization", "automation", "architecture"]
   },
@@ -765,7 +765,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["career", "java", "developer", "growth"]
   },
@@ -779,7 +779,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["spring", "jakarta-ee", "frameworks", "java"]
   },
@@ -793,7 +793,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["microservices", "ai", "agents", "architecture", "generative-ai"]
   },
@@ -807,7 +807,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["database", "migration", "liquibase", "flyway", "practices"]
   },
@@ -821,7 +821,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["ai", "inference", "performance", "spring", "llm"]
   },
@@ -835,7 +835,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["security", "privacy", "devsecops", "practices"]
   },
@@ -849,7 +849,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["career", "leadership", "software-industry"]
   },
@@ -863,7 +863,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "15:50",
-    "start_datetime": "2026-03-05T15:50:00Z",
+    "start_datetime": "2026-03-05T20:50:00Z",
     "session_type": "Talk",
     "tags": ["developer-experience", "productivity", "tools"]
   },
@@ -877,7 +877,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "16:50",
-    "start_datetime": "2026-03-05T16:50:00Z",
+    "start_datetime": "2026-03-05T21:50:00Z",
     "session_type": "Talk",
     "tags": ["java", "podcast", "ai", "agents", "community"]
   },
@@ -891,7 +891,7 @@
     "day": "Day 1",
     "date": "2026-03-05",
     "start_time": "17:30",
-    "start_datetime": "2026-03-05T17:30:00Z",
+    "start_datetime": "2026-03-05T22:30:00Z",
     "session_type": "Social",
     "tags": ["networking", "social"]
   },
@@ -905,7 +905,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "09:00",
-    "start_datetime": "2026-03-06T09:00:00Z",
+    "start_datetime": "2026-03-06T14:00:00Z",
     "session_type": "Keynote",
     "tags": ["keynote", "ai", "security", "hacking"]
   },
@@ -919,7 +919,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "graphs", "context", "rag", "tools"]
   },
@@ -933,7 +933,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "llm", "prompting", "practical", "development"]
   },
@@ -947,7 +947,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["architecture", "cell-architecture", "distributed-systems"]
   },
@@ -961,7 +961,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["java", "jvm", "startup", "performance", "graalvm"]
   },
@@ -975,7 +975,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["spring", "api", "api-versioning", "frameworks"]
   },
@@ -989,7 +989,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "predictive-ai", "machine-learning", "generative-ai"]
   },
@@ -1003,7 +1003,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["maven", "build", "practices", "performance"]
   },
@@ -1017,7 +1017,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-cloud", "production", "cloud-native"]
   },
@@ -1031,7 +1031,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["java", "security", "vulnerabilities", "devsecops"]
   },
@@ -1045,7 +1045,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["ai", "testing", "leadership", "prompting", "software-engineering"]
   },
@@ -1059,7 +1059,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "10:00",
-    "start_datetime": "2026-03-06T10:00:00Z",
+    "start_datetime": "2026-03-06T15:00:00Z",
     "session_type": "Talk",
     "tags": ["boxlang", "jvm-languages", "tools"]
   },
@@ -1073,7 +1073,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "rag", "neo4j", "graphs", "tools", "llm"]
   },
@@ -1087,7 +1087,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "microservices", "architecture", "practical"]
   },
@@ -1101,7 +1101,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["architecture", "hexagonal", "java", "monolith", "layered-architecture"]
   },
@@ -1115,7 +1115,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["java", "jvm", "memory-management", "garbage-collection", "performance"]
   },
@@ -1129,7 +1129,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-boot", "kubernetes", "keda", "autoscaling", "cloud-native"]
   },
@@ -1143,7 +1143,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["llm", "java", "mcp", "spring-ai", "generative-ai"]
   },
@@ -1157,7 +1157,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["platform-engineering", "practices", "devops", "culture"]
   },
@@ -1171,7 +1171,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "tanzu", "modernization", "refactoring", "cloud"]
   },
@@ -1185,7 +1185,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["mcp", "spring-security", "oauth2", "security", "authorization"]
   },
@@ -1199,7 +1199,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["leadership", "career", "tech-lead", "management"]
   },
@@ -1213,7 +1213,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "11:20",
-    "start_datetime": "2026-03-06T11:20:00Z",
+    "start_datetime": "2026-03-06T16:20:00Z",
     "session_type": "Talk",
     "tags": ["java", "rest", "api", "data-oriented-programming", "tools"]
   },
@@ -1227,7 +1227,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "java", "microservices", "fintech", "cloud", "performance"]
   },
@@ -1241,7 +1241,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "rag", "semantic-search", "elasticsearch", "e-commerce"]
   },
@@ -1255,7 +1255,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["architecture", "resilience", "durable-execution", "reliability"]
   },
@@ -1269,7 +1269,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["java", "jvm", "jit", "performance", "compilation"]
   },
@@ -1283,7 +1283,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "spring-boot", "observability", "monitoring", "jvm", "opentelemetry"]
   },
@@ -1297,7 +1297,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["ai", "graphs", "llm", "generative-ai", "context"]
   },
@@ -1311,7 +1311,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["testing", "assertj", "java", "practices"]
   },
@@ -1325,7 +1325,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["spring", "developer-experience", "production", "platform-engineering"]
   },
@@ -1339,7 +1339,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["java", "ai", "generative-ai", "security", "responsible-ai"]
   },
@@ -1353,7 +1353,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["leadership", "architecture", "culture", "organizational-change"]
   },
@@ -1367,7 +1367,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "13:20",
-    "start_datetime": "2026-03-06T13:20:00Z",
+    "start_datetime": "2026-03-06T18:20:00Z",
     "session_type": "Talk",
     "tags": ["java", "career", "tools"]
   },
@@ -1381,7 +1381,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["ai", "prompting", "prompt-engineering", "tools", "llm"]
   },
@@ -1395,7 +1395,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["java", "kafka", "streaming", "fraud-detection", "vector-search", "ai", "practical"]
   },
@@ -1409,7 +1409,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["database", "isolation", "architecture", "transactions"]
   },
@@ -1423,7 +1423,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["java", "async", "reactive", "virtual-threads", "jvm"]
   },
@@ -1437,7 +1437,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["java", "jpa", "json", "database", "spring", "frameworks"]
   },
@@ -1451,7 +1451,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["spring-ai", "langchain4j", "java", "generative-ai", "llm"]
   },
@@ -1465,7 +1465,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["java", "open-source", "community", "jcp", "openjdk", "career"]
   },
@@ -1479,7 +1479,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["spring", "maintenance", "upgrades", "production"]
   },
@@ -1493,7 +1493,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["security", "kafka", "data-streaming", "encryption"]
   },
@@ -1507,7 +1507,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["leadership", "management", "organizational-change", "tech-lead"]
   },
@@ -1521,7 +1521,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "14:40",
-    "start_datetime": "2026-03-06T14:40:00Z",
+    "start_datetime": "2026-03-06T19:40:00Z",
     "session_type": "Talk",
     "tags": ["ai", "gpt", "productivity", "tools", "automation"]
   },
@@ -1535,7 +1535,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "15:40",
-    "start_datetime": "2026-03-06T15:40:00Z",
+    "start_datetime": "2026-03-06T20:40:00Z",
     "session_type": "Talk",
     "tags": ["ai", "agents", "java", "tools", "deployment"]
   },
@@ -1549,7 +1549,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "15:40",
-    "start_datetime": "2026-03-06T15:40:00Z",
+    "start_datetime": "2026-03-06T20:40:00Z",
     "session_type": "Talk",
     "tags": ["microservices", "architecture", "pragmatic"]
   },
@@ -1563,7 +1563,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "15:40",
-    "start_datetime": "2026-03-06T15:40:00Z",
+    "start_datetime": "2026-03-06T20:40:00Z",
     "session_type": "Talk",
     "tags": ["java", "performance", "jvm", "native", "panama"]
   },
@@ -1577,7 +1577,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "15:40",
-    "start_datetime": "2026-03-06T15:40:00Z",
+    "start_datetime": "2026-03-06T20:40:00Z",
     "session_type": "Talk",
     "tags": ["intellij", "debugging", "ide", "practices", "java"]
   },
@@ -1591,7 +1591,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "15:40",
-    "start_datetime": "2026-03-06T15:40:00Z",
+    "start_datetime": "2026-03-06T20:40:00Z",
     "session_type": "Talk",
     "tags": ["spring", "security", "shift-left", "devops", "production"]
   },
@@ -1605,7 +1605,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "15:40",
-    "start_datetime": "2026-03-06T15:40:00Z",
+    "start_datetime": "2026-03-06T20:40:00Z",
     "session_type": "Talk",
     "tags": ["security", "quantum", "encryption", "post-quantum", "cryptography"]
   },
@@ -1619,7 +1619,7 @@
     "day": "Day 2",
     "date": "2026-03-06",
     "start_time": "16:40",
-    "start_datetime": "2026-03-06T16:40:00Z",
+    "start_datetime": "2026-03-06T21:40:00Z",
     "session_type": "Closing",
     "tags": ["closing", "social"]
   }

--- a/scripts/benchmark-native.sh
+++ b/scripts/benchmark-native.sh
@@ -73,15 +73,20 @@ run_one() {
 	local cid
 	local t_start t_ready rss_mb prev_rss=0 stable_count=0
 	t_start="$(date +%s%N)"
-	# Do not use --rm so we can reliably inspect and clean up the container
-	cid="$(docker run -d \
+	# Do not use --rm so we can reliably inspect and clean up the container.
+	# -i keeps stdin open: the default (stdio) profile reads MCP JSON-RPC from
+	# stdin and exits immediately on EOF, which would make every run look like
+	# a crash.
+	cid="$(docker run -d -i \
 		-e SOLR_URL="${SOLR_URL}" \
 		-e SPRING_DOCKER_COMPOSE_ENABLED=false \
 		"${image}")"
 
 	# Poll at 25ms intervals for up to 60s
 	for i in $(seq 1 2400); do
-		if ! docker inspect "${cid}" >/dev/null 2>&1; then
+		# Check that the container is still *running*. `docker inspect` also
+		# succeeds for an exited container, so it never detected a crash.
+		if [[ "$(docker inspect -f '{{.State.Running}}' "${cid}" 2>/dev/null)" != "true" ]]; then
 			docker logs "${cid}" >&2 || true
 			docker rm -f "${cid}" >/dev/null 2>&1 || true
 			echo "container exited prematurely" >&2

--- a/scripts/get-auth0-token.sh
+++ b/scripts/get-auth0-token.sh
@@ -113,10 +113,22 @@ load_env_file() {
     local env_file="${PROJECT_ROOT}/.env"
     if [ -f "$env_file" ]; then
         print_info "Loading configuration from .env file"
-        # Export variables from .env file
-        set -a
-        source "$env_file"
-        set +a
+        # Parse only AUTH0_* assignments rather than sourcing the file.
+        # `source` executes its contents, so any command in .env would run
+        # with this script's privileges.
+        local line key value
+        while IFS= read -r line || [ -n "$line" ]; do
+            # Skip blanks, comments, and anything that is not a simple
+            # AUTH0_<NAME>=<value> assignment.
+            [[ "$line" =~ ^[[:space:]]*(#|$) ]] && continue
+            [[ "$line" =~ ^[[:space:]]*(export[[:space:]]+)?(AUTH0_[A-Za-z0-9_]+)=(.*)$ ]] || continue
+            key="${BASH_REMATCH[2]}"
+            value="${BASH_REMATCH[3]}"
+            # Strip one layer of surrounding quotes, if present
+            value="${value%\"}"; value="${value#\"}"
+            value="${value%\'}"; value="${value#\'}"
+            export "$key=$value"
+        done < "$env_file"
     fi
 }
 

--- a/src/test/java/org/apache/solr/mcp/server/observability/README.md
+++ b/src/test/java/org/apache/solr/mcp/server/observability/README.md
@@ -25,7 +25,7 @@ We use a **three-tier testing strategy** to verify that distributed tracing work
 - Span durations are valid
 
 **How it works**:
-- Uses `InMemorySpanExporter` to capture spans without external infrastructure
+- Uses `SimpleTracer` (micrometer-tracing-test) to capture spans without external infrastructure
 - Uses Awaitility for asynchronous span collection
 - Runs fast (seconds) - suitable for CI/CD pipelines
 
@@ -63,10 +63,10 @@ We use a **three-tier testing strategy** to verify that distributed tracing work
 
 ### 3. Helper Classes
 
-#### `ObservabilityTestConfiguration.java`
+#### `OpenTelemetryTestConfiguration.java`
 Test configuration that provides:
-- `InMemorySpanExporter` bean for capturing spans
-- `SdkTracerProvider` configured to use in-memory exporter
+- A `SimpleTracer` bean (from `micrometer-tracing-test`) that records spans in memory
+- Exposed as `SimpleTracer` rather than `Tracer` so tests can call `getSpans()`
 
 #### `LgtmAssertions.java`
 Helper for querying LGTM stack (Tempo, Prometheus, Loki):
@@ -180,7 +180,7 @@ The **integration tests** (`OtlpExportIntegrationTest`) can be run:
 
 ### Spans Not Appearing in Tests
 
-**Problem**: `InMemorySpanExporter` returns empty list
+**Problem**: `tracer.getSpans()` returns an empty list
 
 **Solutions**:
 1. Verify `@Observed` annotation is present on method
@@ -206,7 +206,8 @@ The **integration tests** (`OtlpExportIntegrationTest`) can be run:
 1. Verify LGTM stack is running: `docker compose ps`
 2. Check OTLP endpoint: `http://localhost:4318/v1/traces`
 3. Verify application properties:
-   - `spring.opentelemetry.tracing.export.otlp.endpoint` is set
+   - `otel.exporter.otlp.endpoint` is set (see `application-http.properties`);
+     tests override `management.otlp.tracing.endpoint` to disable export
    - `management.tracing.sampling.probability=1.0` (100% sampling)
 4. Check application logs for OTLP export errors
 5. Verify Grafana datasource: Grafana → Connections → Data Sources → Tempo
@@ -227,7 +228,7 @@ The **integration tests** (`OtlpExportIntegrationTest`) can be run:
 @Test
 void shouldCreateSpanForMyOperation() throws Exception {
     // Given: Initial state
-    spanExporter.reset();
+    tracer.getSpans().clear();
 
     // When: Execute operation
     myService.doSomething();
@@ -236,7 +237,7 @@ void shouldCreateSpanForMyOperation() throws Exception {
     await()
         .atMost(5, TimeUnit.SECONDS)
         .untilAsserted(() -> {
-            List<SpanData> spans = spanExporter.getFinishedSpanItems();
+            var spans = tracer.getSpans();
             TraceAssertions.assertSpanExists(spans, "MyService.doSomething");
             TraceAssertions.assertSpanHasAttribute(spans, "MyService", "operation", "doSomething");
         });


### PR DESCRIPTION
Every item was checked against the repository, not just reworded.

**Wrong symbols and paths** — `CollectionService` is in `collection/`, not `metadata/`; `@McpToolParameter` should be `@McpToolParam`; the document-creator roles were inverted (formats implement `SolrDocumentCreator` and register with `IndexingDocumentCreator`); `publish-mcp.yml` does not exist; the observability test README documented `InMemorySpanExporter` and `ObservabilityTestConfiguration`, **neither of which exists anywhere except that README**; `ARCHITECTURE.md` listed `*DirectTest` files that do not exist and called record DTOs POJOs; `FAQ.md` claimed 27 tools when there are 11.

**Commands that do not work as written** — `TROUBLESHOOTING.md` piped STDIO logs with `2>&1`, merging diagnostics into the stdout JSON-RPC stream; `ATR_TESTING_GUIDE.md` ran `ls -lh build/distributions/` *after* cd-ing into that directory, and referenced `trstringer/manual-approval@v1` when ASF's allow-list matches by exact SHA; `DEPLOYMENT.md` curled `/actuator/info` unauthenticated when only `/actuator/health` is `permitAll`; `DOCKER_PUBLISHING.md` passed credentials via `-Djib.to.auth.*`, putting tokens in the process argument list; `init-solr.sh` declared `"add-field"` **twice in one JSON object**, so the `name` field was never created; `get-auth0-token.sh` **sourced .env**, executing whatever it contained; `benchmark-native.sh` guarded premature exit with `docker inspect >/dev/null`, which also succeeds for an *exited* container.

**Stale statements and data** — `stdio.md` described the trust boundary as the direct parent process; `books` is documented as having sample data but is created empty; a contributor's real Auth0 tenant URL was committed; `devnexus-2026.json` labelled Atlanta local times with a `Z` suffix — all 116 records converted to true UTC instants, keeping the `Z` that Solr's date parsing requires (`ConferenceEndToEndIntegrationTest`, which indexes this file, still passes).

**Rejected after verification** — the `date +%s%N` portability claim (modern BSD date supports `%N`) and the `gpg --verify` loop (GnuPG strips `.asc` and locates the payload; tested with a throwaway key). The `docs/specs/graalvm-native-image.md` correction is omitted since that file was pruned by #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)