### PR TITLE
feat(jspecify): complete the @NullMarked opt-in for test packages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -289,8 +289,19 @@ tasks.withType<JavaCompile>().configureEach {
     options.errorprone {
         disableAllChecks.set(true) // Other error prone checks are disabled
         option("NullAway:OnlyNullMarked", "true") // Enable nullness checks only in null-marked code
+        option("NullAway:HandleTestAssertionLibraries", "true") // Teach NullAway that JUnit assertNotNull narrows nullness
         error("NullAway") // bump checks from warnings (default) to errors
     }
+}
+
+// NullAway is currently disabled on test compilation. The rollout of @NullMarked
+// to all sub-packages reveals many test sites that unbox / dereference a value
+// declared as @Nullable in production code (e.g. metrics fields that are null
+// when a Solr endpoint is unavailable). Each of those sites can be tightened by
+// extracting a local + assertNotNull, but the volume (~30 sites) makes that a
+// follow-up. Production code is fully enforced.
+tasks.named<JavaCompile>("compileTestJava") {
+    options.errorprone.disable("NullAway")
 }
 
 tasks.build {

--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -44,6 +44,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.mcp.server.config.SolrConfigurationProperties;
 import org.apache.solr.mcp.server.util.PromptNames;
+import org.jspecify.annotations.Nullable;
 import org.springaicommunity.mcp.annotation.McpArg;
 import org.springaicommunity.mcp.annotation.McpComplete;
 import org.springaicommunity.mcp.annotation.McpPrompt;
@@ -659,7 +660,7 @@ public class CollectionService {
 	 * @see #extractCacheStats(NamedList)
 	 * @see #isCacheStatsEmpty(CacheStats)
 	 */
-	public CacheStats getCacheMetrics(String collection) throws SolrServerException, IOException {
+	public @Nullable CacheStats getCacheMetrics(String collection) throws SolrServerException, IOException {
 		String actualCollection = extractCollectionName(collection);
 
 		if (!validateCollectionExists(actualCollection)) {
@@ -673,7 +674,7 @@ public class CollectionService {
 	 * Internal cache metrics fetch that assumes the collection has already been
 	 * validated and the name has been extracted from any shard identifier.
 	 */
-	private CacheStats fetchCacheMetrics(String collection) {
+	private @Nullable CacheStats fetchCacheMetrics(String collection) {
 		try {
 			NamedList<Object> coreMetrics = fetchMetrics(collection, CACHE_METRIC_PREFIX);
 			if (coreMetrics == null) {
@@ -699,7 +700,7 @@ public class CollectionService {
 	 *            the cache statistics to evaluate
 	 * @return true if the stats are null or all cache types are null
 	 */
-	private boolean isCacheStatsEmpty(CacheStats stats) {
+	private boolean isCacheStatsEmpty(@Nullable CacheStats stats) {
 		return stats == null
 				|| (stats.queryResultCache() == null && stats.documentCache() == null && stats.filterCache() == null);
 	}
@@ -711,14 +712,14 @@ public class CollectionService {
 	 *            the core metrics from the Solr Metrics API
 	 * @return CacheStats object containing parsed metrics for all cache types
 	 */
-	private CacheStats extractCacheStats(NamedList<Object> coreMetrics) {
+	private @Nullable CacheStats extractCacheStats(NamedList<Object> coreMetrics) {
 		return new CacheStats(extractSingleCacheInfo(coreMetrics, QUERY_RESULT_CACHE_KEY),
 				extractSingleCacheInfo(coreMetrics, DOCUMENT_CACHE_KEY),
 				extractSingleCacheInfo(coreMetrics, FILTER_CACHE_KEY));
 	}
 
 	@SuppressWarnings("unchecked")
-	private CacheInfo extractSingleCacheInfo(NamedList<Object> coreMetrics, String key) {
+	private @Nullable CacheInfo extractSingleCacheInfo(NamedList<Object> coreMetrics, String key) {
 		NamedList<Object> cache = (NamedList<Object>) coreMetrics.get(key);
 		if (cache == null) {
 			return null;
@@ -775,7 +776,7 @@ public class CollectionService {
 	 * @see #fetchFlatHandlerInfo(String, String, String)
 	 * @see #isHandlerStatsEmpty(HandlerStats)
 	 */
-	public HandlerStats getHandlerMetrics(String collection) throws SolrServerException, IOException {
+	public @Nullable HandlerStats getHandlerMetrics(String collection) throws SolrServerException, IOException {
 		String actualCollection = extractCollectionName(collection);
 
 		if (!validateCollectionExists(actualCollection)) {
@@ -789,7 +790,7 @@ public class CollectionService {
 	 * Internal handler metrics fetch that assumes the collection has already been
 	 * validated and the name has been extracted from any shard identifier.
 	 */
-	private HandlerStats fetchHandlerMetrics(String collection) {
+	private @Nullable HandlerStats fetchHandlerMetrics(String collection) {
 		try {
 			// Handler metrics are flat keys (e.g. QUERY./select.requests) so we
 			// fetch each handler prefix separately and reconstruct HandlerInfo
@@ -831,7 +832,8 @@ public class CollectionService {
 	 * @return the core-level metrics NamedList, or null if unavailable
 	 */
 	@SuppressWarnings("unchecked")
-	private NamedList<Object> fetchMetrics(String collection, String prefix) throws SolrServerException, IOException {
+	private @Nullable NamedList<Object> fetchMetrics(String collection, String prefix)
+			throws SolrServerException, IOException {
 		ModifiableSolrParams params = new ModifiableSolrParams();
 		params.set(GROUP_PARAM, CORE_GROUP);
 		params.set(PREFIX_PARAM, prefix);
@@ -876,7 +878,7 @@ public class CollectionService {
 	 *            {@code QUERY./select.})
 	 * @return HandlerInfo with stats, or null if unavailable
 	 */
-	private HandlerInfo fetchFlatHandlerInfo(String collection, String metricPrefix, String keyPrefix)
+	private @Nullable HandlerInfo fetchFlatHandlerInfo(String collection, String metricPrefix, String keyPrefix)
 			throws SolrServerException, IOException {
 		NamedList<Object> coreMetrics = fetchMetrics(collection, metricPrefix);
 		if (coreMetrics == null) {
@@ -896,7 +898,7 @@ public class CollectionService {
 	 * @return HandlerInfo reconstructed from flat keys, or null if no requests key
 	 *         found
 	 */
-	private HandlerInfo extractFlatHandlerInfo(NamedList<Object> coreMetrics, String keyPrefix) {
+	private @Nullable HandlerInfo extractFlatHandlerInfo(NamedList<Object> coreMetrics, String keyPrefix) {
 		Long requests = getLong(coreMetrics, keyPrefix + REQUESTS_FIELD);
 		if (requests == null) {
 			return null;
@@ -1118,13 +1120,15 @@ public class CollectionService {
 					+ "configSet defaults to _default, numShards and replicationFactor default to 1.")
 	public CollectionCreationResult createCollection(
 			@McpToolParam(description = "Name of the collection to create") String name,
-			@McpToolParam(description = "Configset name. Defaults to _default.", required = false) String configSet,
+			@McpToolParam(
+					description = "Configset name. Defaults to _default.",
+					required = false) @Nullable String configSet,
 			@McpToolParam(
 					description = "Number of shards (SolrCloud only). Defaults to 1.",
-					required = false) Integer numShards,
+					required = false) @Nullable Integer numShards,
 			@McpToolParam(
 					description = "Replication factor (SolrCloud only). Defaults to 1.",
-					required = false) Integer replicationFactor)
+					required = false) @Nullable Integer replicationFactor)
 			throws SolrServerException, IOException {
 
 		if (name == null || name.isBlank()) {

--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionService.java
@@ -712,7 +712,7 @@ public class CollectionService {
 	 *            the core metrics from the Solr Metrics API
 	 * @return CacheStats object containing parsed metrics for all cache types
 	 */
-	private @Nullable CacheStats extractCacheStats(NamedList<Object> coreMetrics) {
+	private CacheStats extractCacheStats(NamedList<Object> coreMetrics) {
 		return new CacheStats(extractSingleCacheInfo(coreMetrics, QUERY_RESULT_CACHE_KEY),
 				extractSingleCacheInfo(coreMetrics, DOCUMENT_CACHE_KEY),
 				extractSingleCacheInfo(coreMetrics, FILTER_CACHE_KEY));

--- a/src/main/java/org/apache/solr/mcp/server/collection/CollectionUtils.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/CollectionUtils.java
@@ -17,6 +17,7 @@
 package org.apache.solr.mcp.server.collection;
 
 import org.apache.solr.common.util.NamedList;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utility class providing type-safe helper methods for extracting values from
@@ -113,7 +114,7 @@ public class CollectionUtils {
 	 * @see Number#longValue()
 	 * @see Long#parseLong(String)
 	 */
-	public static Long getLong(NamedList<Object> response, String key) {
+	public static @Nullable Long getLong(NamedList<Object> response, String key) {
 		Object value = response.get(key);
 		if (value == null)
 			return null;
@@ -180,7 +181,7 @@ public class CollectionUtils {
 	 *         is null
 	 * @see Number#floatValue()
 	 */
-	public static Float getFloat(NamedList<Object> stats, String key) {
+	public static @Nullable Float getFloat(NamedList<Object> stats, String key) {
 		Object value = stats.get(key);
 		if (value == null)
 			return null;
@@ -260,7 +261,7 @@ public class CollectionUtils {
 	 * @see Integer#parseInt(String)
 	 * @see #getLong(NamedList, String)
 	 */
-	public static Integer getInteger(NamedList<Object> response, String key) {
+	public static @Nullable Integer getInteger(NamedList<Object> response, String key) {
 		Object value = response.get(key);
 		if (value == null)
 			return null;

--- a/src/main/java/org/apache/solr/mcp/server/collection/Dtos.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/Dtos.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.Instant;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Data Transfer Objects (DTOs) for the Apache Solr MCP Server.
@@ -95,13 +96,13 @@ record SolrMetrics(
 		 * Cache utilization statistics for query result, document, and filter caches
 		 * (may be null)
 		 */
-		CacheStats cacheStats,
+		@Nullable CacheStats cacheStats,
 
 		/**
 		 * Request handler performance metrics for select and update operations (may be
 		 * null)
 		 */
-		HandlerStats handlerStats,
+		@Nullable HandlerStats handlerStats,
 
 		/** Timestamp when these metrics were collected, formatted as ISO 8601 */
 		@JsonFormat(shape = JsonFormat.Shape.STRING) Instant timestamp) {
@@ -139,13 +140,13 @@ record SolrMetrics(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 record IndexStats(
 		/** Total number of documents in the index (excluding deleted documents) */
-		Integer numDocs,
+		@Nullable Integer numDocs,
 
 		/**
 		 * Number of Lucene segments in the index (lower numbers generally indicate
 		 * better performance)
 		 */
-		Integer segmentCount) {
+		@Nullable Integer segmentCount) {
 }
 
 /**
@@ -223,13 +224,13 @@ record QueryStats(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 record CacheStats(
 		/** Performance metrics for the query result cache */
-		CacheInfo queryResultCache,
+		@Nullable CacheInfo queryResultCache,
 
 		/** Performance metrics for the document cache */
-		CacheInfo documentCache,
+		@Nullable CacheInfo documentCache,
 
 		/** Performance metrics for the filter cache */
-		CacheInfo filterCache) {
+		@Nullable CacheInfo filterCache) {
 }
 
 /**
@@ -262,28 +263,28 @@ record CacheStats(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 record CacheInfo(
 		/** Total number of cache lookup requests */
-		Long lookups,
+		@Nullable Long lookups,
 
 		/** Number of successful cache hits */
-		Long hits,
+		@Nullable Long hits,
 
 		/**
 		 * Cache hit ratio (hits/lookups) - higher values indicate better cache
 		 * performance
 		 */
-		Float hitratio,
+		@Nullable Float hitratio,
 
 		/** Number of new entries added to the cache */
-		Long inserts,
+		@Nullable Long inserts,
 
 		/**
 		 * Number of entries removed due to cache size limits (indicates memory
 		 * pressure)
 		 */
-		Long evictions,
+		@Nullable Long evictions,
 
 		/** Current number of entries stored in the cache */
-		Long size) {
+		@Nullable Long size) {
 }
 
 /**
@@ -317,10 +318,10 @@ record CacheInfo(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 record HandlerStats(
 		/** Performance metrics for the search/select request handler */
-		HandlerInfo selectHandler,
+		@Nullable HandlerInfo selectHandler,
 
 		/** Performance metrics for the document update request handler */
-		HandlerInfo updateHandler) {
+		@Nullable HandlerInfo updateHandler) {
 }
 
 /**
@@ -352,22 +353,22 @@ record HandlerStats(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 record HandlerInfo(
 		/** Total number of requests processed by this handler */
-		Long requests,
+		@Nullable Long requests,
 
 		/** Number of requests that resulted in errors */
-		Long errors,
+		@Nullable Long errors,
 
 		/** Number of requests that exceeded timeout limits */
-		Long timeouts,
+		@Nullable Long timeouts,
 
 		/** Cumulative time spent processing all requests (milliseconds) */
-		Long totalTime,
+		@Nullable Long totalTime,
 
 		/** Average time per request in milliseconds */
-		Float avgTimePerRequest,
+		@Nullable Float avgTimePerRequest,
 
 		/** Average throughput in requests per second */
-		Float avgRequestsPerSecond) {
+		@Nullable Float avgRequestsPerSecond) {
 }
 
 /**
@@ -412,13 +413,13 @@ record SolrHealthStatus(
 		boolean isHealthy,
 
 		/** Detailed error message when isHealthy is false, null when healthy */
-		String errorMessage,
+		@Nullable String errorMessage,
 
 		/** Response time in milliseconds for the health check ping request */
-		Long responseTime,
+		@Nullable Long responseTime,
 
 		/** Total number of documents currently indexed in the collection */
-		Long totalDocuments,
+		@Nullable Long totalDocuments,
 
 		/** Timestamp when this health check was performed, formatted as ISO 8601 */
 		@JsonFormat(shape = JsonFormat.Shape.STRING) Instant lastChecked,

--- a/src/main/java/org/apache/solr/mcp/server/collection/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/collection/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.collection;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/apache/solr/mcp/server/config/JsonResponseParser.java
+++ b/src/main/java/org/apache/solr/mcp/server/config/JsonResponseParser.java
@@ -29,6 +29,7 @@ import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.MediaType;
 
 /**
@@ -102,7 +103,7 @@ class JsonResponseParser extends ResponseParser {
 		return result;
 	}
 
-	private Object convertValue(JsonNode node) {
+	private @Nullable Object convertValue(JsonNode node) {
 		if (node.isNull())
 			return null;
 		if (node.isBoolean())

--- a/src/main/java/org/apache/solr/mcp/server/config/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/config/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.config;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/apache/solr/mcp/server/indexing/documentcreator/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/documentcreator/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.indexing.documentcreator;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/apache/solr/mcp/server/indexing/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/indexing/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.indexing;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/apache/solr/mcp/server/schema/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/schema/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.schema;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/SearchService.java
@@ -31,6 +31,7 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.mcp.server.util.PromptNames;
+import org.jspecify.annotations.Nullable;
 import org.springaicommunity.mcp.annotation.McpArg;
 import org.springaicommunity.mcp.annotation.McpPrompt;
 import org.springaicommunity.mcp.annotation.McpTool;
@@ -262,14 +263,16 @@ public class SearchService {
 			@McpToolParam(
 					description = "Solr q parameter. Lucene syntax; supports local params such as"
 							+ " {!edismax qf='name author'}. If none specified defaults to \"*:*\"",
-					required = false) String query,
+					required = false) @Nullable String query,
 			@McpToolParam(
 					description = "Solr fq parameter: list of filter queries, one filter per entry",
-					required = false) List<String> filterQueries,
-			@McpToolParam(description = "Solr facet fields", required = false) List<String> facetFields,
-			@McpToolParam(description = "Solr sort parameter", required = false) List<Map<String, String>> sortClauses,
-			@McpToolParam(description = "Starting offset for pagination", required = false) Integer start,
-			@McpToolParam(description = "Number of rows to return", required = false) Integer rows)
+					required = false) @Nullable List<String> filterQueries,
+			@McpToolParam(description = "Solr facet fields", required = false) @Nullable List<String> facetFields,
+			@McpToolParam(
+					description = "Solr sort parameter",
+					required = false) @Nullable List<Map<String, String>> sortClauses,
+			@McpToolParam(description = "Starting offset for pagination", required = false) @Nullable Integer start,
+			@McpToolParam(description = "Number of rows to return", required = false) @Nullable Integer rows)
 			throws SolrServerException, IOException {
 
 		// query

--- a/src/main/java/org/apache/solr/mcp/server/search/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/search/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.search;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
+++ b/src/main/java/org/apache/solr/mcp/server/security/HttpSecurityConfiguration.java
@@ -38,10 +38,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 class HttpSecurityConfiguration {
 
 	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:}")
-	private String issuerUrl;
+	private String issuerUrl = "";
 
 	@Value("${mcp.cors.allowed-origins}")
-	private List<String> allowedOrigins;
+	private List<String> allowedOrigins = List.of();
 
 	@Bean
 	@ConditionalOnProperty(name = "http.security.enabled", havingValue = "true", matchIfMissing = true)

--- a/src/main/java/org/apache/solr/mcp/server/security/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/security/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.security;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/apache/solr/mcp/server/util/package-info.java
+++ b/src/main/java/org/apache/solr/mcp/server/util/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/collection/package-info.java
+++ b/src/test/java/org/apache/solr/mcp/server/collection/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.collection;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/config/package-info.java
+++ b/src/test/java/org/apache/solr/mcp/server/config/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.config;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/containerization/package-info.java
+++ b/src/test/java/org/apache/solr/mcp/server/containerization/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.containerization;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/indexing/package-info.java
+++ b/src/test/java/org/apache/solr/mcp/server/indexing/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.indexing;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/observability/package-info.java
+++ b/src/test/java/org/apache/solr/mcp/server/observability/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.observability;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/package-info.java
+++ b/src/test/java/org/apache/solr/mcp/server/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/schema/package-info.java
+++ b/src/test/java/org/apache/solr/mcp/server/schema/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.schema;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/apache/solr/mcp/server/search/package-info.java
+++ b/src/test/java/org/apache/solr/mcp/server/search/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.apache.solr.mcp.server.search;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
> **Stacked on #133** — please merge that first. Until it lands, the diff below
> also shows #133's commits. Once #133 is in, this PR reduces to the six
> `src/test/.../package-info.java` files.

## Why

`@NullMarked` on a `package-info.java` applies to **that package only** — Java
packages are not hierarchical for annotation purposes. Combined with
`NullAway:OnlyNullMarked=true`, an unmarked package is exempt from nullness
checking even though NullAway is configured at `error` level.

#133 marks every main package plus two test packages (`containerization`,
`observability`). This adds the **six that are still unmarked**, so the opt-in
is uniform across main and test:

- `org.apache.solr.mcp.server` (test root)
- `org.apache.solr.mcp.server.collection`
- `org.apache.solr.mcp.server.config`
- `org.apache.solr.mcp.server.indexing`
- `org.apache.solr.mcp.server.schema`
- `org.apache.solr.mcp.server.search`

That takes the test tree from 2/8 packages marked to 8/8.

## Scope

Purely declarative. NullAway remains disabled on `compileTestJava` (see the
comment #133 adds to `build.gradle.kts`), so these files change no compilation
outcome today — they make the opt-in complete and consistent, so that enabling
test-side enforcement later is a one-line change rather than a rediscovery of
which packages were missed.

For sizing the follow-up: flipping that one line on this branch surfaces
**48 NullAway errors across 14 test files**, measured by temporarily replacing
the `compileTestJava` disable and running `./gradlew compileTestJava
--rerun-tasks`. The `~30` in #133's new `build.gradle.kts` comment is an
under-estimate — worth correcting there, but left alone here so this PR stays
additive-only.

Each site is a test unboxing or dereferencing a value that production code
declares `@Nullable` (metrics fields that are null when a Solr endpoint is
unavailable). They're mechanical to fix — extract a local, `assertNotNull` —
but 48 of them is its own PR, not a rider on this one.

## Testing

`./gradlew build` passes on this branch (JDK 25, Testcontainers) — full suite
green, `spotlessApply` reports no reformatting.
