### PR TITLE
docs: drop stale FieldStats from the native-hints list

### DIFF
--- a/dev-docs/graalvm-native-image.md
+++ b/dev-docs/graalvm-native-image.md
@@ -157,11 +157,11 @@ container and value types.
   silently drops the `fields`/`fieldTypes`/`dynamicFields`/`copyFields` arrays —
   a quiet correctness bug, not a crash.
 - **MCP tool response records** — `CollectionCreationResult`, `SolrHealthStatus`,
-  `SolrMetrics`, `IndexStats`, `FieldStats`, `QueryStats`, `CacheStats`,
-  `CacheInfo`, `HandlerStats`, `HandlerInfo`, `SearchResponse`,
-  `SchemaUpdateResult`. These are package-private records the MCP framework
-  dispatches via generic `Object`, so AOT can't see them. They're registered by
-  name with `registerTypeIfPresent`.
+  `SolrMetrics`, `IndexStats`, `QueryStats`, `CacheStats`, `CacheInfo`,
+  `HandlerStats`, `HandlerInfo`, `SearchResponse`, `SchemaUpdateResult`. These
+  are package-private records the MCP framework dispatches via generic
+  `Object`, so AOT can't see them. They're registered by name with
+  `registerTypeIfPresent`.
 - **`logback.xml` resource.** Registered as a resource pattern so logback's
   early (pre-Spring) initialization finds it and installs the `NopStatusListener`.
   Without it, logback falls through to `BasicConfigurator` and writes status


### PR DESCRIPTION
## Summary

Follow-up to #106, which removed the unused `FieldStats` record and its
`registerTypeIfPresent` entry in `SolrNativeHints`.

That PR updated the native-hints list in `AGENTS.md`, but the same list is
duplicated in `dev-docs/graalvm-native-image.md` (added later by #156), so
git had no conflict to flag and the stale `FieldStats` entry survived the
merge. This drops it and reflows the paragraph.

`FieldStats` no longer exists anywhere in the tree:

```
$ grep -rn 'FieldStats' . --exclude-dir=.git --exclude-dir=build
(no matches)
```

## Test plan

Documentation only — no code, no build inputs touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)