### PR TITLE
test(security): prove @PreAuthorize and the actuator boundary are enforced

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
 spring-boot-docker-compose = { module = "org.springframework.boot:spring-boot-docker-compose" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-security-test = { module = "org.springframework.security:spring-security-test" }
 spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
 # Spring AI
 spring-ai-starter-mcp-server-webmvc = { module = "org.springframework.ai:spring-ai-starter-mcp-server-webmvc" }
@@ -102,6 +103,7 @@ spring-boot-dev = [
 
 test = [
     "spring-boot-starter-test",
+    "spring-security-test",
     "spring-boot-testcontainers",
     "spring-ai-spring-boot-testcontainers",
     "testcontainers-junit-jupiter",

--- a/src/test/java/org/apache/solr/mcp/server/security/HttpSecurityFilterChainTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/HttpSecurityFilterChainTest.java
@@ -26,7 +26,6 @@ import java.net.http.HttpResponse;
 import org.apache.solr.mcp.server.TestcontainersConfiguration;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
@@ -57,7 +56,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ActiveProfiles("http")
 @Tag("integration")
 @Testcontainers(disabledWithoutDocker = true)
-@DisabledInNativeImage
 class HttpSecurityFilterChainTest {
 
 	@LocalServerPort

--- a/src/test/java/org/apache/solr/mcp/server/security/HttpSecurityFilterChainTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/HttpSecurityFilterChainTest.java
@@ -17,7 +17,6 @@
 package org.apache.solr.mcp.server.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -29,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -58,6 +58,15 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 class HttpSecurityFilterChainTest {
 
+	/** Open for liveness/readiness probes — the one anonymous actuator path. */
+	private static final String HEALTH_PROBE = "/actuator/health";
+
+	/** Exposes the full dependency tree; must never be anonymous. */
+	private static final String SBOM_ENDPOINT = "/actuator/sbom/application";
+
+	/** Maps the tool surface; must never be anonymous. */
+	private static final String METRICS_ENDPOINT = "/actuator/metrics";
+
 	@LocalServerPort
 	private int port;
 
@@ -68,30 +77,39 @@ class HttpSecurityFilterChainTest {
 
 	@Test
 	void healthProbeIsAnonymouslyReachable() throws Exception {
-		assertEquals(200, statusOf("/actuator/health"),
-				"/actuator/health must stay open for liveness and readiness probes");
+		assertEquals(HttpStatus.OK.value(), statusOf(HEALTH_PROBE),
+				HEALTH_PROBE + " must stay open for liveness and readiness probes");
 	}
 
 	/**
-	 * Denial here is 403, not 401: with no issuer configured there is no
-	 * authentication entry point to challenge with, so Spring Security rejects
-	 * rather than prompting. Wiring an issuer turns the same request into a 401
-	 * carrying {@code WWW-Authenticate: Bearer}. Both are correct denials, so these
-	 * accept either — what must never happen is a 200.
+	 * Denial in this context is exactly {@code 403}, and the assertion pins that
+	 * rather than accepting "401 or 403".
+	 *
+	 * <p>
+	 * This class configures no issuer, so {@link HttpSecurityConfiguration} skips
+	 * the OAuth2 wiring and no {@code BearerTokenAuthenticationEntryPoint} is
+	 * installed. Spring Security falls back to {@code Http403ForbiddenEntryPoint},
+	 * which rejects outright instead of issuing a challenge — measured as
+	 * {@code 403} on every denied path here.
+	 *
+	 * <p>
+	 * Accepting either code would weaken the test in a way that matters: a chain
+	 * that silently lost its bearer-token entry point, or gained one it should not
+	 * have, would still pass. Wiring an issuer turns the same request into a
+	 * {@code 401} carrying {@code WWW-Authenticate: Bearer} — a different
+	 * configuration, and one this class deliberately does not exercise.
 	 */
 	private void assertDenied(String path, String why) throws Exception {
-		int status = statusOf(path);
-		assertTrue(status == 401 || status == 403, why + " — expected 401 or 403, got " + status);
+		assertEquals(HttpStatus.FORBIDDEN.value(), statusOf(path), why);
 	}
 
 	@Test
 	void sbomEndpointRequiresAuthentication() throws Exception {
-		assertDenied("/actuator/sbom/application",
-				"/actuator/sbom/application exposes the full dependency tree and must not be anonymous");
+		assertDenied(SBOM_ENDPOINT, SBOM_ENDPOINT + " exposes the full dependency tree and must not be anonymous");
 	}
 
 	@Test
 	void metricsEndpointRequiresAuthentication() throws Exception {
-		assertDenied("/actuator/metrics", "/actuator/metrics maps the tool surface and must not be anonymous");
+		assertDenied(METRICS_ENDPOINT, METRICS_ENDPOINT + " maps the tool surface and must not be anonymous");
 	}
 }

--- a/src/test/java/org/apache/solr/mcp/server/security/HttpSecurityFilterChainTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/HttpSecurityFilterChainTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.mcp.server.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.apache.solr.mcp.server.TestcontainersConfiguration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Pins the anonymous-access boundary of the {@code http} filter chain.
+ *
+ * <p>
+ * {@link HttpSecurityConfiguration} deliberately splits the actuator: probes
+ * stay open so load balancers and orchestrators can reach them, while every
+ * other endpoint requires authentication — otherwise an unauthenticated caller
+ * could read the dependency tree from {@code /actuator/sbom/application} or
+ * scrape metrics that map the tool surface.
+ *
+ * <p>
+ * That decision is a one-line {@code requestMatchers} rule. Widening it to
+ * {@code permitAll()} would expose all of the above and break no other test, so
+ * this asserts both halves: health open, everything else closed.
+ *
+ * <p>
+ * No issuer is configured here, which is the point — with OAuth2 unwired the
+ * chain must still deny anonymous access rather than fall open.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles("http")
+@Tag("integration")
+@Testcontainers(disabledWithoutDocker = true)
+@DisabledInNativeImage
+class HttpSecurityFilterChainTest {
+
+	@LocalServerPort
+	private int port;
+
+	private int statusOf(String path) throws Exception {
+		HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://localhost:" + port + path)).GET().build();
+		return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString()).statusCode();
+	}
+
+	@Test
+	void healthProbeIsAnonymouslyReachable() throws Exception {
+		assertEquals(200, statusOf("/actuator/health"),
+				"/actuator/health must stay open for liveness and readiness probes");
+	}
+
+	/**
+	 * Denial here is 403, not 401: with no issuer configured there is no
+	 * authentication entry point to challenge with, so Spring Security rejects
+	 * rather than prompting. Wiring an issuer turns the same request into a 401
+	 * carrying {@code WWW-Authenticate: Bearer}. Both are correct denials, so these
+	 * accept either — what must never happen is a 200.
+	 */
+	private void assertDenied(String path, String why) throws Exception {
+		int status = statusOf(path);
+		assertTrue(status == 401 || status == 403, why + " — expected 401 or 403, got " + status);
+	}
+
+	@Test
+	void sbomEndpointRequiresAuthentication() throws Exception {
+		assertDenied("/actuator/sbom/application",
+				"/actuator/sbom/application exposes the full dependency tree and must not be anonymous");
+	}
+
+	@Test
+	void metricsEndpointRequiresAuthentication() throws Exception {
+		assertDenied("/actuator/metrics", "/actuator/metrics maps the tool surface and must not be anonymous");
+	}
+}

--- a/src/test/java/org/apache/solr/mcp/server/security/McpInspectorCorsTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/McpInspectorCorsTest.java
@@ -23,12 +23,16 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 import org.apache.solr.mcp.server.TestcontainersConfiguration;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -62,48 +66,61 @@ class McpInspectorCorsTest {
 	/** The MCP Inspector UI origin, and the shipped default allowlist entry. */
 	private static final String INSPECTOR_ORIGIN = "http://localhost:6274";
 
+	/** Single path the MCP Streamable HTTP transport routes through. */
+	private static final String MCP_ENDPOINT = "/mcp";
+
+	/**
+	 * Methods the Streamable HTTP transport needs: POST sends messages, GET opens
+	 * the stream, DELETE ends the session. Dropping any one breaks a different part
+	 * of the transport.
+	 */
+	private static final List<HttpMethod> TRANSPORT_METHODS = List.of(HttpMethod.GET, HttpMethod.POST,
+			HttpMethod.DELETE);
+
 	@LocalServerPort
 	private int port;
 
-	private HttpResponse<String> preflight(String origin, String method, String requestHeaders) throws Exception {
-		HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/mcp"))
-				.method("OPTIONS", HttpRequest.BodyPublishers.noBody()).header("Origin", origin)
-				.header("Access-Control-Request-Method", method);
+	private HttpResponse<String> preflight(String origin, HttpMethod method, String requestHeaders) throws Exception {
+		HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create("http://localhost:" + port + MCP_ENDPOINT))
+				.method(HttpMethod.OPTIONS.name(), HttpRequest.BodyPublishers.noBody())
+				.header(HttpHeaders.ORIGIN, origin).header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, method.name());
 		if (requestHeaders != null) {
-			builder.header("Access-Control-Request-Headers", requestHeaders);
+			builder.header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, requestHeaders);
 		}
 		return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
 	}
 
 	@Test
 	void inspectorPreflightIsAllowed() throws Exception {
-		HttpResponse<String> response = preflight(INSPECTOR_ORIGIN, "POST", "content-type,authorization");
+		HttpResponse<String> response = preflight(INSPECTOR_ORIGIN, HttpMethod.POST,
+				HttpHeaders.CONTENT_TYPE + "," + HttpHeaders.AUTHORIZATION);
 
-		assertEquals(200, response.statusCode(),
+		assertEquals(HttpStatus.OK.value(), response.statusCode(),
 				"The MCP Inspector cannot connect unless its origin passes preflight. Check that "
 						+ "mcp.cors.allowed-origins still contains " + INSPECTOR_ORIGIN);
-		assertEquals(INSPECTOR_ORIGIN, response.headers().firstValue("Access-Control-Allow-Origin").orElse(null),
+		assertEquals(INSPECTOR_ORIGIN,
+				response.headers().firstValue(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN).orElse(null),
 				"The specific origin must be echoed back; a wildcard is invalid alongside credentials");
-		assertEquals("true", response.headers().firstValue("Access-Control-Allow-Credentials").orElse(null),
+		assertEquals(Boolean.TRUE.toString(),
+				response.headers().firstValue(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS).orElse(null),
 				"The Inspector sends the bearer token as a credentialed request");
 	}
 
 	@Test
 	void inspectorTransportMethodsAreAllowed() throws Exception {
-		String allowed = preflight(INSPECTOR_ORIGIN, "POST", null).headers().firstValue("Access-Control-Allow-Methods")
-				.orElse("");
+		String allowed = preflight(INSPECTOR_ORIGIN, HttpMethod.POST, null).headers()
+				.firstValue(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).orElse("");
 
-		// Streamable HTTP: POST sends messages, GET opens the stream, DELETE ends
-		// the session. Dropping any one breaks a different part of the transport.
-		for (String method : new String[]{"GET", "POST", "DELETE"}) {
-			assertTrue(allowed.contains(method),
+		for (HttpMethod method : TRANSPORT_METHODS) {
+			assertTrue(allowed.contains(method.name()),
 					() -> "MCP Streamable HTTP needs " + method + "; Allow-Methods was: " + allowed);
 		}
 	}
 
 	@Test
 	void unknownOriginIsRejected() throws Exception {
-		assertEquals(403, preflight("http://not-the-inspector.example", "POST", null).statusCode(),
+		assertEquals(HttpStatus.FORBIDDEN.value(),
+				preflight("http://not-the-inspector.example", HttpMethod.POST, null).statusCode(),
 				"Origins outside the allowlist must be refused, otherwise the allowlist is decorative");
 	}
 }

--- a/src/test/java/org/apache/solr/mcp/server/security/McpInspectorCorsTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/McpInspectorCorsTest.java
@@ -26,7 +26,6 @@ import java.net.http.HttpResponse;
 import org.apache.solr.mcp.server.TestcontainersConfiguration;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
@@ -58,7 +57,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ActiveProfiles("http")
 @Tag("integration")
 @Testcontainers(disabledWithoutDocker = true)
-@DisabledInNativeImage
 class McpInspectorCorsTest {
 
 	/** The MCP Inspector UI origin, and the shipped default allowlist entry. */

--- a/src/test/java/org/apache/solr/mcp/server/security/McpInspectorCorsTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/McpInspectorCorsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.mcp.server.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.apache.solr.mcp.server.TestcontainersConfiguration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Pins the CORS contract the MCP Inspector depends on.
+ *
+ * <p>
+ * The Inspector's UI runs at {@code http://localhost:6274} and is the default
+ * value of {@code mcp.cors.allowed-origins}. That default is a plain property:
+ * narrowing it, reordering it, or setting {@code MCP_CORS_ALLOWED_ORIGINS=*}
+ * silently stops the Inspector connecting, and no other test notices.
+ *
+ * <p>
+ * The wildcard case is the trap. {@code setAllowedOrigins} is the strict API,
+ * so {@code *} combined with {@code allowCredentials(true)} does not open the
+ * server up — it rejects <em>every</em> origin, including the Inspector's, with
+ * no warning logged. An operator reaching for {@code *} to "allow everything"
+ * gets the opposite.
+ *
+ * <p>
+ * This replays the exact preflight a browser sends on the Inspector's behalf
+ * and asserts the response permits the request.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles("http")
+@Tag("integration")
+@Testcontainers(disabledWithoutDocker = true)
+@DisabledInNativeImage
+class McpInspectorCorsTest {
+
+	/** The MCP Inspector UI origin, and the shipped default allowlist entry. */
+	private static final String INSPECTOR_ORIGIN = "http://localhost:6274";
+
+	@LocalServerPort
+	private int port;
+
+	private HttpResponse<String> preflight(String origin, String method, String requestHeaders) throws Exception {
+		HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/mcp"))
+				.method("OPTIONS", HttpRequest.BodyPublishers.noBody()).header("Origin", origin)
+				.header("Access-Control-Request-Method", method);
+		if (requestHeaders != null) {
+			builder.header("Access-Control-Request-Headers", requestHeaders);
+		}
+		return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+	}
+
+	@Test
+	void inspectorPreflightIsAllowed() throws Exception {
+		HttpResponse<String> response = preflight(INSPECTOR_ORIGIN, "POST", "content-type,authorization");
+
+		assertEquals(200, response.statusCode(),
+				"The MCP Inspector cannot connect unless its origin passes preflight. Check that "
+						+ "mcp.cors.allowed-origins still contains " + INSPECTOR_ORIGIN);
+		assertEquals(INSPECTOR_ORIGIN, response.headers().firstValue("Access-Control-Allow-Origin").orElse(null),
+				"The specific origin must be echoed back; a wildcard is invalid alongside credentials");
+		assertEquals("true", response.headers().firstValue("Access-Control-Allow-Credentials").orElse(null),
+				"The Inspector sends the bearer token as a credentialed request");
+	}
+
+	@Test
+	void inspectorTransportMethodsAreAllowed() throws Exception {
+		String allowed = preflight(INSPECTOR_ORIGIN, "POST", null).headers().firstValue("Access-Control-Allow-Methods")
+				.orElse("");
+
+		// Streamable HTTP: POST sends messages, GET opens the stream, DELETE ends
+		// the session. Dropping any one breaks a different part of the transport.
+		for (String method : new String[]{"GET", "POST", "DELETE"}) {
+			assertTrue(allowed.contains(method),
+					() -> "MCP Streamable HTTP needs " + method + "; Allow-Methods was: " + allowed);
+		}
+	}
+
+	@Test
+	void unknownOriginIsRejected() throws Exception {
+		assertEquals(403, preflight("http://not-the-inspector.example", "POST", null).statusCode(),
+				"Origins outside the allowlist must be refused, otherwise the allowlist is decorative");
+	}
+}

--- a/src/test/java/org/apache/solr/mcp/server/security/MethodSecurityEnforcementTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/MethodSecurityEnforcementTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.solr.mcp.server.security;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
 import org.apache.solr.mcp.server.TestcontainersConfiguration;
 import org.apache.solr.mcp.server.collection.CollectionService;
 import org.junit.jupiter.api.Tag;
@@ -27,6 +30,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -71,5 +75,36 @@ class MethodSecurityEnforcementTest {
 				"list-collections carries @PreAuthorize(\"isAuthenticated()\") and was called with no "
 						+ "authentication, so method security must reject it. Succeeding means the annotation "
 						+ "is decorative: @EnableMethodSecurity is not in effect for this context.");
+	}
+
+	/**
+	 * The necessary counterpart to
+	 * {@link #unauthenticatedCallToSecuredToolIsRejected()}.
+	 *
+	 * <p>
+	 * A rejection test on its own cannot distinguish "correctly denies anonymous
+	 * callers" from "denies every caller". Both produce the same green result, so a
+	 * gate that were wedged permanently shut would look identical to a working one.
+	 * That gap is not hypothetical: a secured tool call was for a time believed
+	 * broken — reported as denying even valid tokens — and no test existed that
+	 * could have contradicted it. The claim turned out to be false, but only a live
+	 * server proved so.
+	 *
+	 * <p>
+	 * {@code @WithMockUser} installs an authenticated principal before the method
+	 * runs and clears it afterwards, so the {@code ThreadLocal} context cannot leak
+	 * into {@link #unauthenticatedCallToSecuredToolIsRejected()} and make that test
+	 * order-dependent.
+	 */
+	@Test
+	@WithMockUser
+	void authenticatedCallToSecuredToolSucceeds() {
+		List<String> collections = assertDoesNotThrow(() -> collectionService.listCollections(),
+				"list-collections is gated by @PreAuthorize(\"isAuthenticated()\") and was called with an "
+						+ "authenticated principal, so method security must permit it. An AccessDeniedException "
+						+ "here means the gate rejects everyone, not just anonymous callers — the annotation "
+						+ "would be denying valid callers rather than enforcing a boundary.");
+
+		assertNotNull(collections, "an authorized list-collections call must return a result, not null");
 	}
 }

--- a/src/test/java/org/apache/solr/mcp/server/security/MethodSecurityEnforcementTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/MethodSecurityEnforcementTest.java
@@ -22,7 +22,6 @@ import org.apache.solr.mcp.server.TestcontainersConfiguration;
 import org.apache.solr.mcp.server.collection.CollectionService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -53,7 +52,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ActiveProfiles("http")
 @Tag("integration")
 @Testcontainers(disabledWithoutDocker = true)
-@DisabledInNativeImage
 class MethodSecurityEnforcementTest {
 
 	@Autowired

--- a/src/test/java/org/apache/solr/mcp/server/security/MethodSecurityEnforcementTest.java
+++ b/src/test/java/org/apache/solr/mcp/server/security/MethodSecurityEnforcementTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.mcp.server.security;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.solr.mcp.server.TestcontainersConfiguration;
+import org.apache.solr.mcp.server.collection.CollectionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Probe: is {@code @PreAuthorize} actually enforced, or merely present?
+ *
+ * <p>
+ * {@code McpToolRegistrationTest#everyMcpEndpointIsPreAuthorized} asserts the
+ * annotation is declared on every MCP entry point. That is a static check — it
+ * cannot tell whether {@link MethodSecurityConfiguration} is wired such that
+ * the annotation has any runtime effect. If the profile gate or the
+ * {@code http.security.enabled} property condition stopped matching, every
+ * annotation would silently become a no-op and the static test would still
+ * pass.
+ *
+ * <p>
+ * This test runs in the {@code http} profile with security left at its default
+ * (enabled) and invokes a secured method through the Spring proxy with an empty
+ * SecurityContext. Enforcement means an {@link AccessDeniedException}.
+ */
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles("http")
+@Tag("integration")
+@Testcontainers(disabledWithoutDocker = true)
+@DisabledInNativeImage
+class MethodSecurityEnforcementTest {
+
+	@Autowired
+	private CollectionService collectionService;
+
+	/**
+	 * With an entirely empty SecurityContext, Spring Security raises
+	 * {@link AuthenticationCredentialsNotFoundException} (an
+	 * {@code AuthenticationException}) rather than {@code AccessDeniedException} —
+	 * the latter is for an authenticated principal lacking authority. Asserting the
+	 * broad {@code SecurityException}-free supertype would pass for the wrong
+	 * reason, so this pins the specific type.
+	 */
+	@Test
+	void unauthenticatedCallToSecuredToolIsRejected() {
+		assertThrows(AuthenticationCredentialsNotFoundException.class, () -> collectionService.listCollections(),
+				"list-collections carries @PreAuthorize(\"isAuthenticated()\") and was called with no "
+						+ "authentication, so method security must reject it. Succeeding means the annotation "
+						+ "is decorative: @EnableMethodSecurity is not in effect for this context.");
+	}
+}


### PR DESCRIPTION
The security configuration has no test that exercises it at runtime. This adds three, validated by mutation.

## The gap

`McpToolRegistrationTest#everyMcpEndpointIsPreAuthorized` asserts `@PreAuthorize` is present on every MCP entry point, but it is static and cannot tell whether the annotation has any effect. That matters here because `HttpSecurityConfiguration` leaves `/mcp` on `permitAll()` so the MCP layer can dispatch; method security is the only thing between an anonymous caller and every tool.

| mutation | existing tests | this PR |
|---|---|---|
| `@EnableMethodSecurity` commented out | BUILD SUCCESSFUL | FAILS |
| `/actuator/**` widened to `permitAll()` | BUILD SUCCESSFUL | FAILS |
| `mcp.cors.allowed-origins` defaulted to `*` | BUILD SUCCESSFUL | FAILS (2 of 3) |

## What's added

All three run under the `http` profile with security left at its default and share one Spring context (`RANDOM_PORT`, Docker Compose disabled).

- **`MethodSecurityEnforcementTest`** calls a secured tool through the Spring proxy with an empty `SecurityContext` and asserts `AuthenticationCredentialsNotFoundException` (no principal at all; `AccessDeniedException` is for an authenticated principal lacking authority), then the authenticated counterpart succeeds.
- **`HttpSecurityFilterChainTest`** pins the anonymous-access boundary: `/actuator/health` open for probes, `/actuator/sbom/application` and `/actuator/metrics` closed with exactly 403. With no issuer configured there is no authentication entry point, so Spring's default is `AccessDeniedException` rendered as 403; pinning it means a change to the entry-point wiring (which turns the same request into a 401 with `WWW-Authenticate: Bearer`) shows up as a deliberate test change rather than passing silently.
- **`McpInspectorCorsTest`** pins the CORS contract the Inspector depends on: its origin `http://localhost:6274` is the shipped default of `mcp.cors.allowed-origins`, and `*` alongside `allowCredentials(true)` rejects every origin rather than allowing all.

`spring-security-test` is added to the version catalog for `@WithMockUser`; it is not otherwise on the classpath.

The three run in the native image as well as the JVM: Spring's AOT-generated proxies for `@PreAuthorize` are build-time artifacts, unlike Mockito's, so they need no `@DisabledInNativeImage`. Verified with `./gradlew build` and `./gradlew nativeTest -Pnative`.

## Not covered here

OAuth2 wiring when an issuer is configured (the Nimbus decoder is eager, so it needs a reachable issuer or a mock), and the `validateAudienceClaim(true)` behaviour the MCP Authorization spec requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
